### PR TITLE
Change HttpStatusCodeMapper not to wrap responses

### DIFF
--- a/src/Ocelot/Responder/ErrorsToHttpStatusCodeMapper.cs
+++ b/src/Ocelot/Responder/ErrorsToHttpStatusCodeMapper.cs
@@ -1,17 +1,16 @@
 using System.Collections.Generic;
 using System.Linq;
 using Ocelot.Errors;
-using Ocelot.Responses;
 
 namespace Ocelot.Responder
 {
     public class ErrorsToHttpStatusCodeMapper : IErrorsToHttpStatusCodeMapper
     {
-        public Response<int> Map(List<Error> errors)
+        public int Map(List<Error> errors)
         {
             if (errors.Any(e => e.Code == OcelotErrorCode.UnauthenticatedError))
             {
-                return new OkResponse<int>(401);
+                return 401;
             }
 
             if (errors.Any(e => e.Code == OcelotErrorCode.UnauthorizedError 
@@ -19,15 +18,15 @@ namespace Ocelot.Responder
                 || e.Code == OcelotErrorCode.UserDoesNotHaveClaimError
                 || e.Code == OcelotErrorCode.CannotFindClaimError))
             {
-                return new OkResponse<int>(403);
+                return 403;
             }
 
             if (errors.Any(e => e.Code == OcelotErrorCode.RequestTimedOutError))
             {
-                return new OkResponse<int>(503);
+                return 503;
             }
 
-            return new OkResponse<int>(404);
+            return 404;
         }
     }
 }

--- a/src/Ocelot/Responder/IErrorsToHttpStatusCodeMapper.cs
+++ b/src/Ocelot/Responder/IErrorsToHttpStatusCodeMapper.cs
@@ -1,11 +1,13 @@
 ﻿using System.Collections.Generic;
 using Ocelot.Errors;
-using Ocelot.Responses;
 
 namespace Ocelot.Responder
 {
+    /// <summary>
+    /// Map a list OceoltErrors to a single appropriate HTTP status code
+    /// </summary>
     public interface IErrorsToHttpStatusCodeMapper
     {
-        Response<int> Map(List<Error> errors);
+        int Map(List<Error> errors);
     }
 }

--- a/src/Ocelot/Responder/Middleware/ResponderMiddleware.cs
+++ b/src/Ocelot/Responder/Middleware/ResponderMiddleware.cs
@@ -16,12 +16,12 @@ namespace Ocelot.Responder.Middleware
         private readonly IErrorsToHttpStatusCodeMapper _codeMapper;
         private readonly IOcelotLogger _logger;
 
-        public ResponderMiddleware(RequestDelegate next, 
+        public ResponderMiddleware(RequestDelegate next,
             IHttpResponder responder,
             IOcelotLoggerFactory loggerFactory,
-            IRequestScopedDataRepository requestScopedDataRepository, 
+            IRequestScopedDataRepository requestScopedDataRepository,
             IErrorsToHttpStatusCodeMapper codeMapper)
-            :base(requestScopedDataRepository)
+            : base(requestScopedDataRepository)
         {
             _next = next;
             _responder = responder;
@@ -60,14 +60,7 @@ namespace Ocelot.Responder.Middleware
         {
             var statusCode = _codeMapper.Map(errors);
 
-            if (!statusCode.IsError)
-            {
-                _responder.SetErrorResponseOnContext(context, statusCode.Data);
-            }
-            else
-            {
-                _responder.SetErrorResponseOnContext(context, 500);
-            }
+            _responder.SetErrorResponseOnContext(context, statusCode);
         }
     }
 }

--- a/test/Ocelot.UnitTests/Responder/ErrorsToHttpStatusCodeMapperTests.cs
+++ b/test/Ocelot.UnitTests/Responder/ErrorsToHttpStatusCodeMapperTests.cs
@@ -4,7 +4,6 @@ using Ocelot.Errors;
 using Ocelot.Middleware;
 using Ocelot.Requester;
 using Ocelot.Responder;
-using Ocelot.Responses;
 using Shouldly;
 using TestStack.BDDfy;
 using Xunit;
@@ -14,7 +13,7 @@ namespace Ocelot.UnitTests.Responder
     public class ErrorsToHttpStatusCodeMapperTests
     {
         private readonly IErrorsToHttpStatusCodeMapper _codeMapper;
-        private Response<int> _result;
+        private int _result;
         private List<Error> _errors;
 
         public ErrorsToHttpStatusCodeMapperTests()
@@ -77,7 +76,7 @@ namespace Ocelot.UnitTests.Responder
 
         private void ThenTheResponseIsStatusCodeIs(int expectedCode)
         {
-            _result.Data.ShouldBe(expectedCode);
+            _result.ShouldBe(expectedCode);
         }    
     }
 }


### PR DESCRIPTION
As part of #66 we realised that the implementation of
IErrorToHttpStatusCodeMapper would always return a wrapped StatusCode
within an OK response, in turn meaning that ResponderMiddleware would
never fall into the else branch for returning a 500.

This commit removes the wrapping of the status code and removes the unused
logic for generating the 500 status code, giving the mapper full
responsbility for generating the correct status code.