### PR TITLE
Use DiagnosticListner for middleware logging

### DIFF
--- a/src/Ocelot/Authentication/Middleware/AuthenticationMiddleware.cs
+++ b/src/Ocelot/Authentication/Middleware/AuthenticationMiddleware.cs
@@ -34,8 +34,6 @@ namespace Ocelot.Authentication.Middleware
 
         public async Task Invoke(HttpContext context)
         {
-            _logger.TraceMiddlewareEntry();
-
             if (IsAuthenticatedRoute(DownstreamRoute.ReRoute))
             {
                 _logger.LogDebug($"{context.Request.Path} is an authenticated route. {MiddlwareName} checking if client is authenticated");
@@ -46,7 +44,6 @@ namespace Ocelot.Authentication.Middleware
                 {
                     _logger.LogError($"Error getting authentication handler for {context.Request.Path}. {authenticationHandler.Errors.ToErrorString()}");
                     SetPipelineError(authenticationHandler.Errors);
-                    _logger.TraceMiddlewareCompleted();
                     return;
                 }
 
@@ -56,11 +53,7 @@ namespace Ocelot.Authentication.Middleware
                 if (context.User.Identity.IsAuthenticated)
                 {
                     _logger.LogDebug($"Client has been authenticated for {context.Request.Path}");
-
-                    _logger.TraceInvokeNext();
-                        await _next.Invoke(context);
-                    _logger.TraceInvokeNextCompleted();
-                    _logger.TraceMiddlewareCompleted();
+                    await _next.Invoke(context);
                 }
                 else
                 {
@@ -72,8 +65,6 @@ namespace Ocelot.Authentication.Middleware
 
                     _logger.LogError($"Client has NOT been authenticated for {context.Request.Path} and pipeline error set. {error.ToErrorString()}");
                     SetPipelineError(error);
-
-                    _logger.TraceMiddlewareCompleted();
                     return;
                 }
             }
@@ -81,10 +72,7 @@ namespace Ocelot.Authentication.Middleware
             {
                 _logger.LogTrace($"No authentication needed for {context.Request.Path}");
 
-                _logger.TraceInvokeNext();
-                    await _next.Invoke(context);
-                _logger.TraceInvokeNextCompleted();
-                _logger.TraceMiddlewareCompleted();
+                await _next.Invoke(context);
             }
         }
 

--- a/src/Ocelot/Cache/Middleware/OutputCacheMiddleware.cs
+++ b/src/Ocelot/Cache/Middleware/OutputCacheMiddleware.cs
@@ -54,8 +54,6 @@ namespace Ocelot.Cache.Middleware
 
             await _next.Invoke(context);
 
-            _logger.LogDebug("succesfully called next middleware");
-
             if (PipelineError)
             {
                 _logger.LogDebug("there was a pipeline error for {downstreamUrlKey}", downstreamUrlKey);

--- a/src/Ocelot/Claims/Middleware/ClaimsBuilderMiddleware.cs
+++ b/src/Ocelot/Claims/Middleware/ClaimsBuilderMiddleware.cs
@@ -26,8 +26,6 @@ namespace Ocelot.Claims.Middleware
 
         public async Task Invoke(HttpContext context)
         {
-            _logger.LogDebug("started claims middleware");
-
             if (DownstreamRoute.ReRoute.ClaimsToClaims.Any())
             {
                 _logger.LogDebug("this route has instructions to convert claims to other claims");
@@ -42,12 +40,7 @@ namespace Ocelot.Claims.Middleware
                     return;
                 }
             }
-
-            _logger.LogDebug("calling next middleware");
-
             await _next.Invoke(context);
-
-            _logger.LogDebug("succesfully called next middleware");
         }
     }
 }

--- a/src/Ocelot/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Ocelot/DependencyInjection/ServiceCollectionExtensions.cs
@@ -166,6 +166,11 @@ namespace Ocelot.DependencyInjection
             services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
             services.TryAddScoped<IRequestScopedDataRepository, HttpDataRepository>();
             services.AddMemoryCache();
+
+            //Used to log the the start and ending of middleware
+            services.TryAddSingleton<OcelotDiagnosticListener>();
+            services.AddMiddlewareAnalysis();
+
             return services;
         }
     }

--- a/src/Ocelot/DownstreamRouteFinder/Middleware/DownstreamRouteFinderMiddleware.cs
+++ b/src/Ocelot/DownstreamRouteFinder/Middleware/DownstreamRouteFinderMiddleware.cs
@@ -30,8 +30,6 @@ namespace Ocelot.DownstreamRouteFinder.Middleware
 
         public async Task Invoke(HttpContext context)
         {
-            _logger.TraceMiddlewareEntry();
-
             var upstreamUrlPath = context.Request.Path.ToString().SetLastCharacterAs('/');
 
             _logger.LogDebug("upstream url path is {upstreamUrlPath}", upstreamUrlPath);
@@ -43,8 +41,6 @@ namespace Ocelot.DownstreamRouteFinder.Middleware
                 _logger.LogError($"{MiddlwareName} setting pipeline errors. IDownstreamRouteFinder returned {downstreamRoute.Errors.ToErrorString()}");
 
                 SetPipelineError(downstreamRoute.Errors);
-
-                _logger.TraceMiddlewareCompleted();
                 return;
             }
 
@@ -52,12 +48,7 @@ namespace Ocelot.DownstreamRouteFinder.Middleware
 
             SetDownstreamRouteForThisRequest(downstreamRoute.Data);
 
-            _logger.TraceInvokeNext();
-
             await _next.Invoke(context);
-
-            _logger.TraceInvokeNextCompleted();
-            _logger.TraceMiddlewareCompleted();
         }
     }
 }

--- a/src/Ocelot/DownstreamUrlCreator/Middleware/DownstreamUrlCreatorMiddleware.cs
+++ b/src/Ocelot/DownstreamUrlCreator/Middleware/DownstreamUrlCreatorMiddleware.cs
@@ -29,8 +29,6 @@ namespace Ocelot.DownstreamUrlCreator.Middleware
 
         public async Task Invoke(HttpContext context)
         {
-            _logger.LogDebug("started calling downstream url creator middleware");
-
             var dsPath = _replacer
                 .Replace(DownstreamRoute.ReRoute.DownstreamPathTemplate, DownstreamRoute.TemplatePlaceholderNameAndValues);
 
@@ -60,11 +58,7 @@ namespace Ocelot.DownstreamUrlCreator.Middleware
 
             SetDownstreamUrlForThisRequest(dsUrl.Data.Value);
 
-            _logger.LogDebug("calling next middleware");
-
             await _next.Invoke(context);
-
-            _logger.LogDebug("succesfully called next middleware");
         }
     }
 }

--- a/src/Ocelot/Headers/Middleware/HttpRequestHeadersBuilderMiddleware.cs
+++ b/src/Ocelot/Headers/Middleware/HttpRequestHeadersBuilderMiddleware.cs
@@ -26,17 +26,15 @@ namespace Ocelot.Headers.Middleware
 
         public async Task Invoke(HttpContext context)
         {
-            _logger.LogDebug("started calling headers builder middleware");
-
             if (DownstreamRoute.ReRoute.ClaimsToHeaders.Any())
             {
-                _logger.LogDebug("this route has instructions to convert claims to headers");
+                _logger.LogDebug($"{ DownstreamRoute.ReRoute.DownstreamPathTemplate.Value} has instructions to convert claims to headers");
 
                 var response = _addHeadersToRequest.SetHeadersOnContext(DownstreamRoute.ReRoute.ClaimsToHeaders, context);
 
                 if (response.IsError)
                 {
-                    _logger.LogDebug("there was an error setting headers on context, setting pipeline error");
+                    _logger.LogDebug("Error setting headers on context, setting pipeline error");
 
                     SetPipelineError(response.Errors);
                     return;
@@ -45,11 +43,7 @@ namespace Ocelot.Headers.Middleware
                 _logger.LogDebug("headers have been set on context");
             }
 
-            _logger.LogDebug("calling next middleware");
-
             await _next.Invoke(context);
-
-            _logger.LogDebug("succesfully called next middleware");
         }
     }
 }

--- a/src/Ocelot/LoadBalancer/Middleware/LoadBalancingMiddleware.cs
+++ b/src/Ocelot/LoadBalancer/Middleware/LoadBalancingMiddleware.cs
@@ -28,41 +28,37 @@ namespace Ocelot.LoadBalancer.Middleware
 
         public async Task Invoke(HttpContext context)
         {
-            _logger.LogDebug("started calling load balancing middleware");
-
             var loadBalancer = _loadBalancerHouse.Get(DownstreamRoute.ReRoute.ReRouteKey);
             if(loadBalancer.IsError)
             {
+                _logger.LogDebug("there was an error retriving the loadbalancer, setting pipeline error");
                 SetPipelineError(loadBalancer.Errors);
                 return;
             }
 
             var hostAndPort = await loadBalancer.Data.Lease();
             if(hostAndPort.IsError)
-            { 
+            {
+                _logger.LogDebug("there was an error leasing the loadbalancer, setting pipeline error");
                 SetPipelineError(hostAndPort.Errors);
                 return;
             }
 
             SetHostAndPortForThisRequest(hostAndPort.Data);
 
-            _logger.LogDebug("calling next middleware");
-
             try
             {
                 await _next.Invoke(context);
-
-                loadBalancer.Data.Release(hostAndPort.Data);
             }
             catch (Exception)
             {
-                loadBalancer.Data.Release(hostAndPort.Data);
-                 
-                 _logger.LogDebug("error calling next middleware, exception will be thrown to global handler");
+                _logger.LogDebug("Exception calling next middleware, exception will be thrown to global handler");
                 throw;
             }
-
-            _logger.LogDebug("succesfully called next middleware");
+            finally
+            {
+                loadBalancer.Data.Release(hostAndPort.Data);
+            }
         }
     }
 }

--- a/src/Ocelot/Logging/OcelotDiagnosticListener.cs
+++ b/src/Ocelot/Logging/OcelotDiagnosticListener.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DiagnosticAdapter;
+
+namespace Ocelot.Logging
+{
+    public class OcelotDiagnosticListener
+    {
+        [DiagnosticName("Microsoft.AspNetCore.MiddlewareAnalysis.MiddlewareStarting")]
+        public virtual void OnMiddlewareStarting(HttpContext httpContext, string name)
+        {
+            Console.WriteLine($"MiddlewareStarting: {name}; {httpContext.Request.Path}");
+        }
+
+        [DiagnosticName("Microsoft.AspNetCore.MiddlewareAnalysis.MiddlewareException")]
+        public virtual void OnMiddlewareException(Exception exception, string name)
+        {
+            Console.WriteLine($"MiddlewareException: {name}; {exception.Message}");
+        }
+
+        [DiagnosticName("Microsoft.AspNetCore.MiddlewareAnalysis.MiddlewareFinished")]
+        public virtual void OnMiddlewareFinished(HttpContext httpContext, string name)
+        {
+            Console.WriteLine($"MiddlewareFinished: {name}; {httpContext.Response.StatusCode}");
+        }
+    }
+}

--- a/src/Ocelot/Ocelot.csproj
+++ b/src/Ocelot/Ocelot.csproj
@@ -21,10 +21,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="1.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Extensions.DiagnosticAdapter" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.1" />

--- a/src/Ocelot/QueryStrings/Middleware/QueryStringBuilderMiddleware.cs
+++ b/src/Ocelot/QueryStrings/Middleware/QueryStringBuilderMiddleware.cs
@@ -26,11 +26,9 @@ namespace Ocelot.QueryStrings.Middleware
 
         public async Task Invoke(HttpContext context)
         {
-            _logger.LogDebug("started calling query string builder middleware");
-
             if (DownstreamRoute.ReRoute.ClaimsToQueries.Any())
             {
-                _logger.LogDebug("this route has instructions to convert claims to queries");
+                _logger.LogDebug($"{DownstreamRoute.ReRoute.DownstreamPathTemplate.Value} has instructions to convert claims to queries");
 
                 var response = _addQueriesToRequest.SetQueriesOnContext(DownstreamRoute.ReRoute.ClaimsToQueries, context);
 
@@ -43,11 +41,7 @@ namespace Ocelot.QueryStrings.Middleware
                 }
             }
 
-            _logger.LogDebug("calling next middleware");
-
             await _next.Invoke(context);
-
-            _logger.LogDebug("succesfully called next middleware");
         }
     }
 }

--- a/src/Ocelot/RequestId/Middleware/RequestIdMiddleware.cs
+++ b/src/Ocelot/RequestId/Middleware/RequestIdMiddleware.cs
@@ -17,7 +17,7 @@ namespace Ocelot.RequestId.Middleware
         public RequestIdMiddleware(RequestDelegate next,
             IOcelotLoggerFactory loggerFactory,
             IRequestScopedDataRepository requestScopedDataRepository)
-            :base(requestScopedDataRepository)
+            : base(requestScopedDataRepository)
         {
             _next = next;
             _logger = loggerFactory.CreateLogger<RequestIdMiddleware>();
@@ -25,17 +25,11 @@ namespace Ocelot.RequestId.Middleware
         }
 
         public async Task Invoke(HttpContext context)
-        {         
-            _logger.TraceMiddlewareEntry();
-
+        {
             SetOcelotRequestId(context);
 
             _logger.LogDebug("set requestId");
-
-            _logger.TraceInvokeNext();
-                await _next.Invoke(context);
-            _logger.TraceInvokeNextCompleted();
-            _logger.TraceMiddlewareCompleted();
+            await _next.Invoke(context);
         }
 
         private void SetOcelotRequestId(HttpContext context)

--- a/src/Ocelot/Responder/Middleware/ResponderMiddleware.cs
+++ b/src/Ocelot/Responder/Middleware/ResponderMiddleware.cs
@@ -34,10 +34,7 @@ namespace Ocelot.Responder.Middleware
 
         public async Task Invoke(HttpContext context)
         {
-            _logger.TraceMiddlewareEntry();
-            _logger.TraceInvokeNext();
-                await _next.Invoke(context);
-            _logger.TraceInvokeNextCompleted();
+            await _next.Invoke(context);
 
             if (PipelineError)
             {
@@ -51,7 +48,6 @@ namespace Ocelot.Responder.Middleware
                 _logger.LogDebug("no pipeline errors, setting and returning completed response");
                 await _responder.SetResponseOnHttpContext(context, HttpResponseMessage);
             }
-            _logger.TraceMiddlewareCompleted();
         }
 
         private void SetErrorResponse(HttpContext context, List<Error> errors)


### PR DESCRIPTION
I was well off the mark with my original thoughts around logging, after reading [https://andrewlock.net/understanding-your-middleware-pipeline-with-the-middleware-analysis-package/](https://andrewlock.net/understanding-your-middleware-pipeline-with-the-middleware-analysis-package/) it turns out that you are able to to "listen" to when a middleware starts and ends, instead of having to remeber to log within the middleware itself.

This PR takes Andrew Lock's default implementation and hooks it up to the DiagnosticListener. 
