### PR TITLE
Set multiple verbs in the UpstreamHttpMethod property

### DIFF
--- a/src/Ocelot/Configuration/Builder/ReRouteBuilder.cs
+++ b/src/Ocelot/Configuration/Builder/ReRouteBuilder.cs
@@ -67,11 +67,13 @@ namespace Ocelot.Configuration.Builder
             _upstreamTemplatePattern = input;
             return this;
         }
-        public ReRouteBuilder WithUpstreamHttpMethod(string input)
+
+        public ReRouteBuilder WithUpstreamHttpMethod(List<string> input)
         {
-            _upstreamHttpMethod = string.IsNullOrWhiteSpace(input) ? new List<HttpMethod>() : input.Split(',').Select(x => new HttpMethod(x.Trim())).ToList();
+            _upstreamHttpMethod = (input.Count == 0) ? new List<HttpMethod>() : input.Select(x => new HttpMethod(x.Trim())).ToList();
             return this;
         }
+
         public ReRouteBuilder WithIsAuthenticated(bool input)
         {
             _isAuthenticated = input;
@@ -144,7 +146,6 @@ namespace Ocelot.Configuration.Builder
             return this;
         }
        
-
         public ReRouteBuilder WithLoadBalancerKey(string loadBalancerKey)
         {
             _loadBalancerKey = loadBalancerKey;

--- a/src/Ocelot/Configuration/Builder/ReRouteBuilder.cs
+++ b/src/Ocelot/Configuration/Builder/ReRouteBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Net.Http;
 using Ocelot.Values;
+using System.Linq;
 
 namespace Ocelot.Configuration.Builder
 {
@@ -11,7 +12,7 @@ namespace Ocelot.Configuration.Builder
         private string _downstreamPathTemplate;
         private string _upstreamTemplate;
         private string _upstreamTemplatePattern;
-        private string _upstreamHttpMethod;
+        private List<HttpMethod> _upstreamHttpMethod;
         private bool _isAuthenticated;
         private List<ClaimToThing> _configHeaderExtractorProperties;
         private List<ClaimToThing> _claimToClaims;
@@ -68,7 +69,7 @@ namespace Ocelot.Configuration.Builder
         }
         public ReRouteBuilder WithUpstreamHttpMethod(string input)
         {
-            _upstreamHttpMethod = input;
+            _upstreamHttpMethod = string.IsNullOrWhiteSpace(input) ? new List<HttpMethod>() : input.Split(',').Select(x => new HttpMethod(x.Trim())).ToList();
             return this;
         }
         public ReRouteBuilder WithIsAuthenticated(bool input)
@@ -180,7 +181,7 @@ namespace Ocelot.Configuration.Builder
             return new ReRoute(
                 new PathTemplate(_downstreamPathTemplate), 
                 new PathTemplate(_upstreamTemplate), 
-                new HttpMethod(_upstreamHttpMethod), 
+                _upstreamHttpMethod, 
                 _upstreamTemplatePattern, 
                 _isAuthenticated, 
                 _authenticationOptions,

--- a/src/Ocelot/Configuration/File/FileReRoute.cs
+++ b/src/Ocelot/Configuration/File/FileReRoute.cs
@@ -6,6 +6,7 @@ namespace Ocelot.Configuration.File
     {
         public FileReRoute()
         {
+            UpstreamHttpMethod = new List<string>();
             AddHeadersToRequest = new Dictionary<string, string>();
             AddClaimsToRequest = new Dictionary<string, string>();
             RouteClaimsRequirement = new Dictionary<string, string>();
@@ -18,7 +19,7 @@ namespace Ocelot.Configuration.File
 
         public string DownstreamPathTemplate { get; set; }
         public string UpstreamPathTemplate { get; set; }
-        public string UpstreamHttpMethod { get; set; }
+        public List<string> UpstreamHttpMethod { get; set; }
         public FileAuthenticationOptions AuthenticationOptions { get; set; }
         public Dictionary<string, string> AddHeadersToRequest { get; set; }
         public Dictionary<string, string> AddClaimsToRequest { get; set; }

--- a/src/Ocelot/Configuration/ReRoute.cs
+++ b/src/Ocelot/Configuration/ReRoute.cs
@@ -8,7 +8,7 @@ namespace Ocelot.Configuration
     {
         public ReRoute(PathTemplate downstreamPathTemplate, 
             PathTemplate upstreamPathTemplate, 
-            HttpMethod upstreamHttpMethod, 
+            List<HttpMethod> upstreamHttpMethod, 
             string upstreamTemplatePattern, 
             bool isAuthenticated, 
             AuthenticationOptions authenticationOptions, 
@@ -64,7 +64,7 @@ namespace Ocelot.Configuration
         public PathTemplate DownstreamPathTemplate { get; private set; }
         public PathTemplate UpstreamPathTemplate { get; private set; }
         public string UpstreamTemplatePattern { get; private set; }
-        public HttpMethod UpstreamHttpMethod { get; private set; }
+        public List<HttpMethod> UpstreamHttpMethod { get; private set; }
         public bool IsAuthenticated { get; private set; }
         public bool IsAuthorised { get; private set; }
         public AuthenticationOptions AuthenticationOptions { get; private set; }

--- a/src/Ocelot/DownstreamRouteFinder/Finder/DownstreamRouteFinder.cs
+++ b/src/Ocelot/DownstreamRouteFinder/Finder/DownstreamRouteFinder.cs
@@ -26,7 +26,7 @@ namespace Ocelot.DownstreamRouteFinder.Finder
         {
             var configuration = await _configProvider.Get();
 
-            var applicableReRoutes = configuration.Data.ReRoutes.Where(r => string.Equals(r.UpstreamHttpMethod.Method.ToLower(), upstreamHttpMethod.ToLower(), StringComparison.CurrentCultureIgnoreCase));
+            var applicableReRoutes = configuration.Data.ReRoutes.Where(r => r.UpstreamHttpMethod.Count == 0 || r.UpstreamHttpMethod.Select(x => x.Method.ToLower()).Contains(upstreamHttpMethod.ToLower()));
 
             foreach (var reRoute in applicableReRoutes)
             {

--- a/test/Ocelot.AcceptanceTests/AuthenticationTests.cs
+++ b/test/Ocelot.AcceptanceTests/AuthenticationTests.cs
@@ -48,7 +48,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamHost = _downstreamServiceHost,
                             DownstreamScheme = _downstreamServiceScheme,
                             UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = "Post",
+                            UpstreamHttpMethod = new List<string> { "Post" },
                             AuthenticationOptions = new FileAuthenticationOptions
                             {
 								AllowedScopes =  new List<string>(),
@@ -86,7 +86,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamHost = _downstreamServiceHost,
                             DownstreamScheme = _downstreamServiceScheme,
                             UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = "Post",
+                            UpstreamHttpMethod = new List<string> { "Post" },
                             AuthenticationOptions = new FileAuthenticationOptions
                             {
 								AllowedScopes =  new List<string>(),
@@ -124,7 +124,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamHost = _downstreamServiceHost,
                             DownstreamScheme = _downstreamServiceScheme,
                             UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = "Get",
+                            UpstreamHttpMethod = new List<string> { "Get" },
                             AuthenticationOptions = new FileAuthenticationOptions
                             {
 								AllowedScopes =  new List<string>(),
@@ -164,8 +164,8 @@ namespace Ocelot.AcceptanceTests
                             DownstreamHost = _downstreamServiceHost,
                             DownstreamScheme = _downstreamServiceScheme,
                             UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = "Post",
-                            
+                            UpstreamHttpMethod = new List<string> { "Post" },
+
                             AuthenticationOptions = new FileAuthenticationOptions
                             {
 								AllowedScopes =  new List<string>(),
@@ -205,8 +205,8 @@ namespace Ocelot.AcceptanceTests
                             DownstreamHost = _downstreamServiceHost,
                             DownstreamScheme = _downstreamServiceScheme,
                             UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = "Post",
-                             AuthenticationOptions = new FileAuthenticationOptions
+                            UpstreamHttpMethod = new List<string> { "Post" },
+                            AuthenticationOptions = new FileAuthenticationOptions
                             {
 								AllowedScopes = new List<string>(),
                                 Provider = "IdentityServer",

--- a/test/Ocelot.AcceptanceTests/AuthorisationTests.cs
+++ b/test/Ocelot.AcceptanceTests/AuthorisationTests.cs
@@ -42,7 +42,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamScheme = "http",
                             DownstreamHost = "localhost",
                             UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = "Get",
+                            UpstreamHttpMethod = new List<string> { "Get" },
                             AuthenticationOptions = new FileAuthenticationOptions
                             {
 								AllowedScopes =  new List<string>(),
@@ -99,7 +99,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamScheme = "http",
                             DownstreamHost = "localhost",
                             UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = "Get",
+                            UpstreamHttpMethod = new List<string> { "Get" },
                             AuthenticationOptions = new FileAuthenticationOptions
                             {
 								AllowedScopes =  new List<string>(),

--- a/test/Ocelot.AcceptanceTests/CachingTests.cs
+++ b/test/Ocelot.AcceptanceTests/CachingTests.cs
@@ -36,7 +36,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamScheme = "http",
                             DownstreamHost = "localhost",
                             UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = "Get",
+                            UpstreamHttpMethod = new List<string> { "Get" },
                             FileCacheOptions = new FileCacheOptions
                             {
                                 TtlSeconds = 100
@@ -72,7 +72,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamScheme = "http",
                             DownstreamHost = "localhost",
                             UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = "Get",
+                            UpstreamHttpMethod = new List<string> { "Get" },
                             FileCacheOptions = new FileCacheOptions
                             {
                                 TtlSeconds = 1

--- a/test/Ocelot.AcceptanceTests/CaseSensitiveRoutingTests.cs
+++ b/test/Ocelot.AcceptanceTests/CaseSensitiveRoutingTests.cs
@@ -35,7 +35,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamScheme = "http",
                             DownstreamHost = "localhost",
                             UpstreamPathTemplate = "/products/{productId}",
-                            UpstreamHttpMethod = "Get",
+                            UpstreamHttpMethod = new List<string> { "Get" },
                         }
                     }
             };
@@ -62,7 +62,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamScheme = "http",
                             DownstreamHost = "localhost",
                             UpstreamPathTemplate = "/products/{productId}",
-                            UpstreamHttpMethod = "Get",
+                            UpstreamHttpMethod = new List<string> { "Get" },
                             ReRouteIsCaseSensitive = false,
                         }
                     }
@@ -90,7 +90,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamScheme = "http",
                             DownstreamHost = "localhost",
                             UpstreamPathTemplate = "/products/{productId}",
-                            UpstreamHttpMethod = "Get",
+                            UpstreamHttpMethod = new List<string> { "Get" },
                             ReRouteIsCaseSensitive = true,
                         }
                     }
@@ -118,7 +118,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamScheme = "http",
                             DownstreamHost = "localhost",
                             UpstreamPathTemplate = "/PRODUCTS/{productId}",
-                            UpstreamHttpMethod = "Get",
+                            UpstreamHttpMethod = new List<string> { "Get" },
                             ReRouteIsCaseSensitive = true,
                         }
                     }
@@ -146,7 +146,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamScheme = "http",
                             DownstreamHost = "localhost",
                             UpstreamPathTemplate = "/products/{productId}",
-                            UpstreamHttpMethod = "Get",
+                            UpstreamHttpMethod = new List<string> { "Get" },
                             ReRouteIsCaseSensitive = true,
                         }
                     }
@@ -174,7 +174,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamScheme = "http",
                             DownstreamHost = "localhost",
                             UpstreamPathTemplate = "/PRODUCTS/{productId}",
-                            UpstreamHttpMethod = "Get",
+                            UpstreamHttpMethod = new List<string> { "Get" },
                             ReRouteIsCaseSensitive = true,
                         }
                     }

--- a/test/Ocelot.AcceptanceTests/ClaimsToHeadersForwardingTests.cs
+++ b/test/Ocelot.AcceptanceTests/ClaimsToHeadersForwardingTests.cs
@@ -56,7 +56,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamScheme = "http",
                             DownstreamHost = "localhost",
                             UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = "Get",
+                            UpstreamHttpMethod = new List<string> { "Get" },
                             AuthenticationOptions = new FileAuthenticationOptions
                             {
 								AllowedScopes = new List<string>

--- a/test/Ocelot.AcceptanceTests/ClaimsToQueryStringForwardingTests.cs
+++ b/test/Ocelot.AcceptanceTests/ClaimsToQueryStringForwardingTests.cs
@@ -56,7 +56,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamScheme = "http",
                             DownstreamHost = "localhost",
                             UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = "Get",
+                            UpstreamHttpMethod = new List<string> { "Get" },
                             AuthenticationOptions = new FileAuthenticationOptions
                             {
 								AllowedScopes = new List<string>

--- a/test/Ocelot.AcceptanceTests/ClientRateLimitTests.cs
+++ b/test/Ocelot.AcceptanceTests/ClientRateLimitTests.cs
@@ -47,7 +47,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamScheme = "http",
                             DownstreamHost = "localhost",
                             UpstreamPathTemplate = "/api/ClientRateLimit",
-                            UpstreamHttpMethod = "Get",
+                            UpstreamHttpMethod = new List<string> { "Get" },
                             RequestIdKey = _steps.RequestIdKey,
                              
                             RateLimitOptions =    new FileRateLimitRule()
@@ -102,7 +102,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamScheme = "http",
                             DownstreamHost = "localhost",
                             UpstreamPathTemplate = "/api/ClientRateLimit",
-                            UpstreamHttpMethod = "Get",
+                            UpstreamHttpMethod = new List<string> { "Get" },
                             RequestIdKey = _steps.RequestIdKey,
 
                             RateLimitOptions =    new FileRateLimitRule()

--- a/test/Ocelot.AcceptanceTests/ConfigurationInConsulTests.cs
+++ b/test/Ocelot.AcceptanceTests/ConfigurationInConsulTests.cs
@@ -44,8 +44,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamHost = "localhost",
                             DownstreamPort = 51779,
                             UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = "Get",
-
+                            UpstreamHttpMethod = new List<string> { "Get" },
                         }
                     },
                 GlobalConfiguration = new FileGlobalConfiguration()

--- a/test/Ocelot.AcceptanceTests/CustomMiddlewareTests.cs
+++ b/test/Ocelot.AcceptanceTests/CustomMiddlewareTests.cs
@@ -50,7 +50,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamScheme = "http",
                             DownstreamHost = "localhost",
                             UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = "Get",
+                            UpstreamHttpMethod = new List<string> { "Get" },
                         }
                     }
             };
@@ -87,8 +87,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamScheme = "http",
                             DownstreamHost = "localhost",
                             UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = "Get",
-
+                            UpstreamHttpMethod = new List<string> { "Get" },
                         }
                     }
             };
@@ -125,8 +124,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamScheme = "http",
                             DownstreamHost = "localhost",
                             UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = "Get",
-
+                            UpstreamHttpMethod = new List<string> { "Get" },
                         }
                     }
             };
@@ -163,7 +161,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamScheme = "http",
                             DownstreamHost = "localhost",
                             UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = "Get",
+                            UpstreamHttpMethod = new List<string> { "Get" },
                         }
                     }
             };
@@ -200,7 +198,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamScheme = "http",
                             DownstreamHost = "localhost",
                             UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = "Get",
+                            UpstreamHttpMethod = new List<string> { "Get" },
                         }
                     }
             };
@@ -237,7 +235,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamScheme = "http",
                             DownstreamHost = "localhost",
                             UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = "Get",
+                            UpstreamHttpMethod = new List<string> { "Get" },
                         }
                     }
             };

--- a/test/Ocelot.AcceptanceTests/QoSTests.cs
+++ b/test/Ocelot.AcceptanceTests/QoSTests.cs
@@ -39,7 +39,7 @@ namespace Ocelot.AcceptanceTests
                         DownstreamHost = "localhost",
                         DownstreamPort = 51879,
                         UpstreamPathTemplate = "/",
-                        UpstreamHttpMethod = "Get",
+                        UpstreamHttpMethod = new List<string> { "Get" },
                         QoSOptions = new FileQoSOptions
                         {
                             ExceptionsAllowedBeforeBreaking = 1,
@@ -83,7 +83,7 @@ namespace Ocelot.AcceptanceTests
                         DownstreamHost = "localhost",
                         DownstreamPort = 51879,
                         UpstreamPathTemplate = "/",
-                        UpstreamHttpMethod = "Get",
+                        UpstreamHttpMethod = new List<string> { "Get" },
                         QoSOptions = new FileQoSOptions
                         {
                             ExceptionsAllowedBeforeBreaking = 1,
@@ -98,7 +98,7 @@ namespace Ocelot.AcceptanceTests
                         DownstreamHost = "localhost",
                         DownstreamPort = 51880,
                         UpstreamPathTemplate = "working",
-                        UpstreamHttpMethod = "Get",
+                        UpstreamHttpMethod = new List<string> { "Get" },
                     }
                 }
             };

--- a/test/Ocelot.AcceptanceTests/RequestIdTests.cs
+++ b/test/Ocelot.AcceptanceTests/RequestIdTests.cs
@@ -38,7 +38,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamScheme = "http",
                             DownstreamHost = "localhost",
                             UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = "Get",
+                            UpstreamHttpMethod = new List<string> { "Get" },
                             RequestIdKey = _steps.RequestIdKey,
                          }
                     }
@@ -66,8 +66,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamScheme = "http",
                             DownstreamHost = "localhost",
                             UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = "Get",
- 
+                            UpstreamHttpMethod = new List<string> { "Get" },
                         }
                     }
             };
@@ -96,7 +95,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamScheme = "http",
                             DownstreamHost = "localhost",
                             UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = "Get",
+                            UpstreamHttpMethod = new List<string> { "Get" },
                         }
                     },
                 GlobalConfiguration = new FileGlobalConfiguration

--- a/test/Ocelot.AcceptanceTests/ReturnsErrorTests.cs
+++ b/test/Ocelot.AcceptanceTests/ReturnsErrorTests.cs
@@ -31,7 +31,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/",
                             UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = "Get",
+                            UpstreamHttpMethod = new List<string> { "Get" },
                             DownstreamPort = 53876,
                             DownstreamScheme = "http",
                             DownstreamHost = "localhost"

--- a/test/Ocelot.AcceptanceTests/RoutingTests.cs
+++ b/test/Ocelot.AcceptanceTests/RoutingTests.cs
@@ -45,7 +45,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamHost = "localhost",
                             DownstreamPort = 51879,
                             UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = "Get",
+                            UpstreamHttpMethod = new List<string> { "Get" },
                         }
                     }
             };
@@ -73,8 +73,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamHost = "localhost",
                             DownstreamPort = 51879,
                             UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = "Get",
- 
+                            UpstreamHttpMethod = new List<string> { "Get" },
                         }
                     }
             };
@@ -102,8 +101,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamHost = "localhost/",
                             DownstreamPort = 51879,
                             UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = "Get",
- 
+                            UpstreamHttpMethod = new List<string> { "Get" },
                         }
                     }
             };
@@ -131,8 +129,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamHost = "localhost",
                             DownstreamPort = 51879,
                             UpstreamPathTemplate = "/products/",
-                            UpstreamHttpMethod = "Get",
- 
+                            UpstreamHttpMethod = new List<string> { "Get" },
                         }
                     }
             };
@@ -160,7 +157,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamHost = "localhost",
                             DownstreamPort = 51879,
                             UpstreamPathTemplate = "/products",
-                            UpstreamHttpMethod = "Get",
+                            UpstreamHttpMethod = new List<string> { "Get" },
                         }
                     }
             };
@@ -188,7 +185,7 @@ namespace Ocelot.AcceptanceTests
                         DownstreamHost = "localhost",
                         DownstreamPort = 51879,
                         UpstreamPathTemplate = "/products/{productId}",
-                        UpstreamHttpMethod = "Get",
+                        UpstreamHttpMethod = new List<string> { "Get" },
                         QoSOptions = new FileQoSOptions()
                         {
                             ExceptionsAllowedBeforeBreaking = 3,
@@ -221,7 +218,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamHost = "localhost",
                             DownstreamPort = 51879,
                             UpstreamPathTemplate = "/products/{productId}",
-                            UpstreamHttpMethod = "Get",
+                            UpstreamHttpMethod = new List<string> { "Get" },
                         }
                     }
             };
@@ -249,7 +246,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamPort = 51879,
                             DownstreamScheme = "http",
                             UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = "Post", 
+                            UpstreamHttpMethod = new List<string> { "Post" },
                         }
                     }
             };
@@ -277,7 +274,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamScheme = "http",
                             DownstreamHost = "localhost",
                             DownstreamPort = 51879,
-                            UpstreamHttpMethod = "Get",
+                            UpstreamHttpMethod = new List<string> { "Get" },
                         }
                     }
             };
@@ -305,7 +302,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamHost = "localhost",
                             DownstreamPort = 51879,
                             UpstreamPathTemplate = "/myApp1Name/api/{urlPath}",
-                            UpstreamHttpMethod = "Get",
+                            UpstreamHttpMethod = new List<string> { "Get" },
                         }
                     }
             };
@@ -333,7 +330,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamPort = 51879,
                             DownstreamScheme = "http",
                             UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = "Get, Post",
+                            UpstreamHttpMethod = new List<string> { "Get", "Post" },
                         }
                     }
             };
@@ -361,7 +358,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamPort = 51879,
                             DownstreamScheme = "http",
                             UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = "",
+                            UpstreamHttpMethod = new List<string>(),
                         }
                     }
             };

--- a/test/Ocelot.AcceptanceTests/RoutingTests.cs
+++ b/test/Ocelot.AcceptanceTests/RoutingTests.cs
@@ -319,6 +319,62 @@ namespace Ocelot.AcceptanceTests
                 .BDDfy();
         }
 
+        [Fact]
+        public void should_return_response_201_with_simple_url_and_multiple_upstream_http_method()
+        {
+            var configuration = new FileConfiguration
+            {
+                ReRoutes = new List<FileReRoute>
+                    {
+                        new FileReRoute
+                        {
+                            DownstreamPathTemplate = "/",
+                            DownstreamHost = "localhost",
+                            DownstreamPort = 51879,
+                            DownstreamScheme = "http",
+                            UpstreamPathTemplate = "/",
+                            UpstreamHttpMethod = "Get, Post",
+                        }
+                    }
+            };
+
+            this.Given(x => x.GivenThereIsAServiceRunningOn("http://localhost:51879", 201, string.Empty))
+                .And(x => _steps.GivenThereIsAConfiguration(configuration))
+                .And(x => _steps.GivenOcelotIsRunning())
+                .And(x => _steps.GivenThePostHasContent("postContent"))
+                .When(x => _steps.WhenIPostUrlOnTheApiGateway("/"))
+                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.Created))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_return_response_200_with_simple_url_and_any_upstream_http_method()
+        {
+            var configuration = new FileConfiguration
+            {
+                ReRoutes = new List<FileReRoute>
+                    {
+                        new FileReRoute
+                        {
+                            DownstreamPathTemplate = "/",
+                            DownstreamHost = "localhost",
+                            DownstreamPort = 51879,
+                            DownstreamScheme = "http",
+                            UpstreamPathTemplate = "/",
+                            UpstreamHttpMethod = "",
+                        }
+                    }
+            };
+
+            this.Given(x => x.GivenThereIsAServiceRunningOn("http://localhost:51879", 200, "Hello from Laura"))
+                .And(x => _steps.GivenThereIsAConfiguration(configuration))
+                .And(x => _steps.GivenOcelotIsRunning())
+                .When(x => _steps.WhenIGetUrlOnTheApiGateway("/"))
+                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+                .And(x => _steps.ThenTheResponseBodyShouldBe("Hello from Laura"))
+                .BDDfy();
+        }
+
         private void GivenThereIsAServiceRunningOn(string url, int statusCode, string responseBody)
         {
             _builder = new WebHostBuilder()

--- a/test/Ocelot.AcceptanceTests/ServiceDiscoveryTests.cs
+++ b/test/Ocelot.AcceptanceTests/ServiceDiscoveryTests.cs
@@ -69,7 +69,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
                             UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = "Get",
+                            UpstreamHttpMethod = new List<string> { "Get" },
                             ServiceName = serviceName,
                             LoadBalancer = "LeastConnection",
                         }

--- a/test/Ocelot.IntegrationTests/AdministrationTests.cs
+++ b/test/Ocelot.IntegrationTests/AdministrationTests.cs
@@ -94,7 +94,7 @@ namespace Ocelot.IntegrationTests
                         DownstreamPort = 80,
                         DownstreamScheme = "https",
                         DownstreamPathTemplate = "/",
-                        UpstreamHttpMethod = "get",
+                        UpstreamHttpMethod = new List<string> { "get" },
                         UpstreamPathTemplate = "/"
                     },
                     new FileReRoute()
@@ -103,7 +103,7 @@ namespace Ocelot.IntegrationTests
                         DownstreamPort = 80,
                         DownstreamScheme = "https",
                         DownstreamPathTemplate = "/",
-                        UpstreamHttpMethod = "get",
+                        UpstreamHttpMethod = new List<string> { "get" },
                         UpstreamPathTemplate = "/test"
                     }
                 }
@@ -136,7 +136,7 @@ namespace Ocelot.IntegrationTests
                         DownstreamPort = 80,
                         DownstreamScheme = "https",
                         DownstreamPathTemplate = "/",
-                        UpstreamHttpMethod = "get",
+                        UpstreamHttpMethod = new List<string> { "get" },
                         UpstreamPathTemplate = "/"
                     },
                     new FileReRoute()
@@ -145,7 +145,7 @@ namespace Ocelot.IntegrationTests
                         DownstreamPort = 80,
                         DownstreamScheme = "https",
                         DownstreamPathTemplate = "/",
-                        UpstreamHttpMethod = "get",
+                        UpstreamHttpMethod = new List<string> { "get" },
                         UpstreamPathTemplate = "/test"
                     }
                 }
@@ -165,7 +165,7 @@ namespace Ocelot.IntegrationTests
                         DownstreamPort = 80,
                         DownstreamScheme = "http",
                         DownstreamPathTemplate = "/geoffrey",
-                        UpstreamHttpMethod = "get",
+                        UpstreamHttpMethod = new List<string> { "get" },
                         UpstreamPathTemplate = "/"
                     },
                     new FileReRoute()
@@ -174,7 +174,7 @@ namespace Ocelot.IntegrationTests
                         DownstreamPort = 443,
                         DownstreamScheme = "https",
                         DownstreamPathTemplate = "/blooper/{productId}",
-                        UpstreamHttpMethod = "post",
+                        UpstreamHttpMethod = new List<string> { "post" },
                         UpstreamPathTemplate = "/test"
                     }
                 }

--- a/test/Ocelot.IntegrationTests/ThreadSafeHeadersTests.cs
+++ b/test/Ocelot.IntegrationTests/ThreadSafeHeadersTests.cs
@@ -55,7 +55,7 @@ namespace Ocelot.IntegrationTests
                             DownstreamHost = "localhost",
                             DownstreamPort = 51879,
                             UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = "Get",
+                            UpstreamHttpMethod = new List<string> { "Get" },
                         }
                     }
             };

--- a/test/Ocelot.ManualTest/configuration.json
+++ b/test/Ocelot.ManualTest/configuration.json
@@ -1,311 +1,311 @@
 ﻿{
-    "ReRoutes": [
-        {
-            "DownstreamPathTemplate": "/",
-            "DownstreamScheme": "http",
-            "DownstreamHost": "localhost",
-            "DownstreamPort": 52876,
-            "UpstreamPathTemplate": "/identityserverexample",
-            "UpstreamHttpMethod": "Get",
-            "QoSOptions": {
-                "ExceptionsAllowedBeforeBreaking": 3,
-                "DurationOfBreak": 10,
-                "TimeoutValue": 5000
-            },
-            "AuthenticationOptions": {
-                "Provider": "IdentityServer",
-                "ProviderRootUrl": "http://localhost:52888",
-                "ApiName": "api",
-                "AllowedScopes": [
-                    "openid",
-                    "offline_access"
-                ],
-                "ApiSecret": "secret"
-            },
-            "AddHeadersToRequest": {
-                "CustomerId": "Claims[CustomerId] > value",
-                "LocationId": "Claims[LocationId] > value",
-                "UserType": "Claims[sub] > value[0] > |",
-                "UserId": "Claims[sub] > value[1] > |"
-            },
-            "AddClaimsToRequest": {
-                "CustomerId": "Claims[CustomerId] > value",
-                "LocationId": "Claims[LocationId] > value",
-                "UserType": "Claims[sub] > value[0] > |",
-                "UserId": "Claims[sub] > value[1] > |"
-            },
-            "AddQueriesToRequest": {
-                "CustomerId": "Claims[CustomerId] > value",
-                "LocationId": "Claims[LocationId] > value",
-                "UserType": "Claims[sub] > value[0] > |",
-                "UserId": "Claims[sub] > value[1] > |"
-            },
-            "RouteClaimsRequirement": {
-                "UserType": "registered"
-            },
-            "RequestIdKey": "OcRequestId"
-        },
-        {
-            "DownstreamPathTemplate": "/posts",
-            "DownstreamScheme": "https",
-            "DownstreamHost": "jsonplaceholder.typicode.com",
-            "DownstreamPort": 443,
-            "UpstreamPathTemplate": "/posts",
-            "UpstreamHttpMethod": "Get",
-            "QoSOptions": {
-                "ExceptionsAllowedBeforeBreaking": 3,
-                "DurationOfBreak": 10,
-                "TimeoutValue": 5000
-            }
-        },
-        {
-            "DownstreamPathTemplate": "/posts/{postId}",
-            "DownstreamScheme": "http",
-            "DownstreamHost": "jsonplaceholder.typicode.com",
-            "DownstreamPort": 80,
-            "UpstreamPathTemplate": "/posts/{postId}",
-            "UpstreamHttpMethod": "Get",
-            "QoSOptions": {
-                "ExceptionsAllowedBeforeBreaking": 3,
-                "DurationOfBreak": 10,
-                "TimeoutValue": 5000
-            }
-        },
-        {
-            "DownstreamPathTemplate": "/posts/{postId}/comments",
-            "DownstreamScheme": "http",
-            "DownstreamHost": "jsonplaceholder.typicode.com",
-            "DownstreamPort": 80,
-            "UpstreamPathTemplate": "/posts/{postId}/comments",
-            "UpstreamHttpMethod": "Get",
-            "QoSOptions": {
-                "ExceptionsAllowedBeforeBreaking": 3,
-                "DurationOfBreak": 10,
-                "TimeoutValue": 5000
-            }
-        },
-        {
-            "DownstreamPathTemplate": "/comments",
-            "DownstreamScheme": "http",
-            "DownstreamHost": "jsonplaceholder.typicode.com",
-            "DownstreamPort": 80,
-            "UpstreamPathTemplate": "/comments",
-            "UpstreamHttpMethod": "Get",
-            "QoSOptions": {
-                "ExceptionsAllowedBeforeBreaking": 3,
-                "DurationOfBreak": 10,
-                "TimeoutValue": 5000
-            }
-        },
-        {
-            "DownstreamPathTemplate": "/posts",
-            "DownstreamScheme": "http",
-            "DownstreamHost": "jsonplaceholder.typicode.com",
-            "DownstreamPort": 80,
-            "UpstreamPathTemplate": "/posts",
-            "UpstreamHttpMethod": "Post",
-            "QoSOptions": {
-                "ExceptionsAllowedBeforeBreaking": 3,
-                "DurationOfBreak": 10,
-                "TimeoutValue": 5000
-            }
-        },
-        {
-            "DownstreamPathTemplate": "/posts/{postId}",
-            "DownstreamScheme": "http",
-            "DownstreamHost": "jsonplaceholder.typicode.com",
-            "DownstreamPort": 80,
-            "UpstreamPathTemplate": "/posts/{postId}",
-            "UpstreamHttpMethod": "Put",
-            "QoSOptions": {
-                "ExceptionsAllowedBeforeBreaking": 3,
-                "DurationOfBreak": 10,
-                "TimeoutValue": 5000
-            }
-        },
-        {
-            "DownstreamPathTemplate": "/posts/{postId}",
-            "DownstreamScheme": "http",
-            "DownstreamHost": "jsonplaceholder.typicode.com",
-            "DownstreamPort": 80,
-            "UpstreamPathTemplate": "/posts/{postId}",
-            "UpstreamHttpMethod": "Patch",
-            "QoSOptions": {
-                "ExceptionsAllowedBeforeBreaking": 3,
-                "DurationOfBreak": 10,
-                "TimeoutValue": 5000
-            }
-        },
-        {
-            "DownstreamPathTemplate": "/posts/{postId}",
-            "DownstreamScheme": "http",
-            "DownstreamHost": "jsonplaceholder.typicode.com",
-            "DownstreamPort": 80,
-            "UpstreamPathTemplate": "/posts/{postId}",
-            "UpstreamHttpMethod": "Delete",
-            "QoSOptions": {
-                "ExceptionsAllowedBeforeBreaking": 3,
-                "DurationOfBreak": 10,
-                "TimeoutValue": 5000
-            }
-        },
-        {
-            "DownstreamPathTemplate": "/api/products",
-            "DownstreamScheme": "http",
-            "DownstreamHost": "jsonplaceholder.typicode.com",
-            "DownstreamPort": 80,
-            "UpstreamPathTemplate": "/products",
-            "UpstreamHttpMethod": "Get",
-            "QoSOptions": {
-                "ExceptionsAllowedBeforeBreaking": 3,
-                "DurationOfBreak": 10,
-                "TimeoutValue": 5000
-            },
-            "FileCacheOptions": { "TtlSeconds": 15 }
-        },
-        {
-            "DownstreamPathTemplate": "/api/products/{productId}",
-            "DownstreamScheme": "http",
-            "DownstreamHost": "jsonplaceholder.typicode.com",
-            "DownstreamPort": 80,
-            "UpstreamPathTemplate": "/products/{productId}",
-            "UpstreamHttpMethod": "Get",
-            "FileCacheOptions": { "TtlSeconds": 15 }
-        },
-        {
-            "DownstreamPathTemplate": "/api/products",
-            "DownstreamScheme": "http",
-            "DownstreamHost": "products20161126090340.azurewebsites.net",
-            "DownstreamPort": 80,
-            "UpstreamPathTemplate": "/products",
-            "UpstreamHttpMethod": "Post",
-            "QoSOptions": {
-                "ExceptionsAllowedBeforeBreaking": 3,
-                "DurationOfBreak": 10,
-                "TimeoutValue": 5000
-            }
-        },
-        {
-            "DownstreamPathTemplate": "/api/products/{productId}",
-            "DownstreamScheme": "http",
-            "DownstreamHost": "products20161126090340.azurewebsites.net",
-            "DownstreamPort": 80,
-            "UpstreamPathTemplate": "/products/{productId}",
-            "UpstreamHttpMethod": "Put",
-            "QoSOptions": {
-                "ExceptionsAllowedBeforeBreaking": 3,
-                "DurationOfBreak": 10,
-                "TimeoutValue": 5000
-            },
-            "FileCacheOptions": { "TtlSeconds": 15 }
-        },
-        {
-            "DownstreamPathTemplate": "/api/products/{productId}",
-            "DownstreamScheme": "http",
-            "DownstreamHost": "products20161126090340.azurewebsites.net",
-            "DownstreamPort": 80,
-            "UpstreamPathTemplate": "/products/{productId}",
-            "UpstreamHttpMethod": "Delete",
-            "QoSOptions": {
-                "ExceptionsAllowedBeforeBreaking": 3,
-                "DurationOfBreak": 10,
-                "TimeoutValue": 5000
-            },
-            "FileCacheOptions": { "TtlSeconds": 15 }
-        },
-        {
-            "DownstreamPathTemplate": "/api/customers",
-            "DownstreamScheme": "http",
-            "DownstreamHost": "customers20161126090811.azurewebsites.net",
-            "DownstreamPort": 80,
-            "UpstreamPathTemplate": "/customers",
-            "UpstreamHttpMethod": "Get",
-            "QoSOptions": {
-                "ExceptionsAllowedBeforeBreaking": 3,
-                "DurationOfBreak": 10,
-                "TimeoutValue": 5000
-            },
-            "FileCacheOptions": { "TtlSeconds": 15 }
-        },
-        {
-            "DownstreamPathTemplate": "/api/customers/{customerId}",
-            "DownstreamScheme": "http",
-            "DownstreamHost": "customers20161126090811.azurewebsites.net",
-            "DownstreamPort": 80,
-            "UpstreamPathTemplate": "/customers/{customerId}",
-            "UpstreamHttpMethod": "Get",
-            "QoSOptions": {
-                "ExceptionsAllowedBeforeBreaking": 3,
-                "DurationOfBreak": 10,
-                "TimeoutValue": 5000
-            },
-            "FileCacheOptions": { "TtlSeconds": 15 }
-        },
-        {
-            "DownstreamPathTemplate": "/api/customers",
-            "DownstreamScheme": "http",
-            "DownstreamHost": "customers20161126090811.azurewebsites.net",
-            "DownstreamPort": 80,
-            "UpstreamPathTemplate": "/customers",
-            "UpstreamHttpMethod": "Post",
-            "QoSOptions": {
-                "ExceptionsAllowedBeforeBreaking": 3,
-                "DurationOfBreak": 10,
-                "TimeoutValue": 5000
-            },
-            "FileCacheOptions": { "TtlSeconds": 15 }
-        },
-        {
-            "DownstreamPathTemplate": "/api/customers/{customerId}",
-            "DownstreamScheme": "http",
-            "DownstreamHost": "customers20161126090811.azurewebsites.net",
-            "DownstreamPort": 80,
-            "UpstreamPathTemplate": "/customers/{customerId}",
-            "UpstreamHttpMethod": "Put",
-            "QoSOptions": {
-                "ExceptionsAllowedBeforeBreaking": 3,
-                "DurationOfBreak": 10,
-                "TimeoutValue": 5000
-            },
-            "FileCacheOptions": { "TtlSeconds": 15 }
-        },
-        {
-            "DownstreamPathTemplate": "/api/customers/{customerId}",
-            "DownstreamScheme": "http",
-            "DownstreamHost": "customers20161126090811.azurewebsites.net",
-            "DownstreamPort": 80,
-            "UpstreamPathTemplate": "/customers/{customerId}",
-            "UpstreamHttpMethod": "Delete",
-            "QoSOptions": {
-                "ExceptionsAllowedBeforeBreaking": 3,
-                "DurationOfBreak": 10,
-                "TimeoutValue": 5000
-            },
-            "FileCacheOptions": { "TtlSeconds": 15 }
-        },
-        {
-            "DownstreamPathTemplate": "/posts",
-            "DownstreamScheme": "http",
-            "DownstreamHost": "jsonplaceholder.typicode.com",
-            "DownstreamPort": 80,
-            "UpstreamPathTemplate": "/posts/",
-            "UpstreamHttpMethod": "Get",
-            "QoSOptions": {
-                "ExceptionsAllowedBeforeBreaking": 3,
-                "DurationOfBreak": 10,
-                "TimeoutValue": 5000
-            },
-            "FileCacheOptions": { "TtlSeconds": 15 }
-        },
-        {
-            "DownstreamPathTemplate": "/",
-            "DownstreamScheme": "http",
-            "DownstreamHost": "www.bbc.co.uk",
-            "DownstreamPort": 80,
-            "UpstreamPathTemplate": "/bbc/",
-            "UpstreamHttpMethod": "Get"
-        }
-    ],
+  "ReRoutes": [
+    {
+      "DownstreamPathTemplate": "/",
+      "DownstreamScheme": "http",
+      "DownstreamHost": "localhost",
+      "DownstreamPort": 52876,
+      "UpstreamPathTemplate": "/identityserverexample",
+      "UpstreamHttpMethod": [ "Get" ],
+      "QoSOptions": {
+        "ExceptionsAllowedBeforeBreaking": 3,
+        "DurationOfBreak": 10,
+        "TimeoutValue": 5000
+      },
+      "AuthenticationOptions": {
+        "Provider": "IdentityServer",
+        "ProviderRootUrl": "http://localhost:52888",
+        "ApiName": "api",
+        "AllowedScopes": [
+          "openid",
+          "offline_access"
+        ],
+        "ApiSecret": "secret"
+      },
+      "AddHeadersToRequest": {
+        "CustomerId": "Claims[CustomerId] > value",
+        "LocationId": "Claims[LocationId] > value",
+        "UserType": "Claims[sub] > value[0] > |",
+        "UserId": "Claims[sub] > value[1] > |"
+      },
+      "AddClaimsToRequest": {
+        "CustomerId": "Claims[CustomerId] > value",
+        "LocationId": "Claims[LocationId] > value",
+        "UserType": "Claims[sub] > value[0] > |",
+        "UserId": "Claims[sub] > value[1] > |"
+      },
+      "AddQueriesToRequest": {
+        "CustomerId": "Claims[CustomerId] > value",
+        "LocationId": "Claims[LocationId] > value",
+        "UserType": "Claims[sub] > value[0] > |",
+        "UserId": "Claims[sub] > value[1] > |"
+      },
+      "RouteClaimsRequirement": {
+        "UserType": "registered"
+      },
+      "RequestIdKey": "OcRequestId"
+    },
+    {
+      "DownstreamPathTemplate": "/posts",
+      "DownstreamScheme": "https",
+      "DownstreamHost": "jsonplaceholder.typicode.com",
+      "DownstreamPort": 443,
+      "UpstreamPathTemplate": "/posts",
+      "UpstreamHttpMethod": [ "Get" ],
+      "QoSOptions": {
+        "ExceptionsAllowedBeforeBreaking": 3,
+        "DurationOfBreak": 10,
+        "TimeoutValue": 5000
+      }
+    },
+    {
+      "DownstreamPathTemplate": "/posts/{postId}",
+      "DownstreamScheme": "http",
+      "DownstreamHost": "jsonplaceholder.typicode.com",
+      "DownstreamPort": 80,
+      "UpstreamPathTemplate": "/posts/{postId}",
+      "UpstreamHttpMethod": [ "Get" ],
+      "QoSOptions": {
+        "ExceptionsAllowedBeforeBreaking": 3,
+        "DurationOfBreak": 10,
+        "TimeoutValue": 5000
+      }
+    },
+    {
+      "DownstreamPathTemplate": "/posts/{postId}/comments",
+      "DownstreamScheme": "http",
+      "DownstreamHost": "jsonplaceholder.typicode.com",
+      "DownstreamPort": 80,
+      "UpstreamPathTemplate": "/posts/{postId}/comments",
+      "UpstreamHttpMethod": [ "Get" ],
+      "QoSOptions": {
+        "ExceptionsAllowedBeforeBreaking": 3,
+        "DurationOfBreak": 10,
+        "TimeoutValue": 5000
+      }
+    },
+    {
+      "DownstreamPathTemplate": "/comments",
+      "DownstreamScheme": "http",
+      "DownstreamHost": "jsonplaceholder.typicode.com",
+      "DownstreamPort": 80,
+      "UpstreamPathTemplate": "/comments",
+      "UpstreamHttpMethod": [ "Get" ],
+      "QoSOptions": {
+        "ExceptionsAllowedBeforeBreaking": 3,
+        "DurationOfBreak": 10,
+        "TimeoutValue": 5000
+      }
+    },
+    {
+      "DownstreamPathTemplate": "/posts",
+      "DownstreamScheme": "http",
+      "DownstreamHost": "jsonplaceholder.typicode.com",
+      "DownstreamPort": 80,
+      "UpstreamPathTemplate": "/posts",
+      "UpstreamHttpMethod": [ "Post" ],
+      "QoSOptions": {
+        "ExceptionsAllowedBeforeBreaking": 3,
+        "DurationOfBreak": 10,
+        "TimeoutValue": 5000
+      }
+    },
+    {
+      "DownstreamPathTemplate": "/posts/{postId}",
+      "DownstreamScheme": "http",
+      "DownstreamHost": "jsonplaceholder.typicode.com",
+      "DownstreamPort": 80,
+      "UpstreamPathTemplate": "/posts/{postId}",
+      "UpstreamHttpMethod": [ "Put" ],
+      "QoSOptions": {
+        "ExceptionsAllowedBeforeBreaking": 3,
+        "DurationOfBreak": 10,
+        "TimeoutValue": 5000
+      }
+    },
+    {
+      "DownstreamPathTemplate": "/posts/{postId}",
+      "DownstreamScheme": "http",
+      "DownstreamHost": "jsonplaceholder.typicode.com",
+      "DownstreamPort": 80,
+      "UpstreamPathTemplate": "/posts/{postId}",
+      "UpstreamHttpMethod": [ "Patch" ],
+      "QoSOptions": {
+        "ExceptionsAllowedBeforeBreaking": 3,
+        "DurationOfBreak": 10,
+        "TimeoutValue": 5000
+      }
+    },
+    {
+      "DownstreamPathTemplate": "/posts/{postId}",
+      "DownstreamScheme": "http",
+      "DownstreamHost": "jsonplaceholder.typicode.com",
+      "DownstreamPort": 80,
+      "UpstreamPathTemplate": "/posts/{postId}",
+      "UpstreamHttpMethod": [ "Delete" ],
+      "QoSOptions": {
+        "ExceptionsAllowedBeforeBreaking": 3,
+        "DurationOfBreak": 10,
+        "TimeoutValue": 5000
+      }
+    },
+    {
+      "DownstreamPathTemplate": "/api/products",
+      "DownstreamScheme": "http",
+      "DownstreamHost": "jsonplaceholder.typicode.com",
+      "DownstreamPort": 80,
+      "UpstreamPathTemplate": "/products",
+      "UpstreamHttpMethod": [ "Get" ],
+      "QoSOptions": {
+        "ExceptionsAllowedBeforeBreaking": 3,
+        "DurationOfBreak": 10,
+        "TimeoutValue": 5000
+      },
+      "FileCacheOptions": { "TtlSeconds": 15 }
+    },
+    {
+      "DownstreamPathTemplate": "/api/products/{productId}",
+      "DownstreamScheme": "http",
+      "DownstreamHost": "jsonplaceholder.typicode.com",
+      "DownstreamPort": 80,
+      "UpstreamPathTemplate": "/products/{productId}",
+      "UpstreamHttpMethod": [ "Get" ],
+      "FileCacheOptions": { "TtlSeconds": 15 }
+    },
+    {
+      "DownstreamPathTemplate": "/api/products",
+      "DownstreamScheme": "http",
+      "DownstreamHost": "products20161126090340.azurewebsites.net",
+      "DownstreamPort": 80,
+      "UpstreamPathTemplate": "/products",
+      "UpstreamHttpMethod": [ "Post" ],
+      "QoSOptions": {
+        "ExceptionsAllowedBeforeBreaking": 3,
+        "DurationOfBreak": 10,
+        "TimeoutValue": 5000
+      }
+    },
+    {
+      "DownstreamPathTemplate": "/api/products/{productId}",
+      "DownstreamScheme": "http",
+      "DownstreamHost": "products20161126090340.azurewebsites.net",
+      "DownstreamPort": 80,
+      "UpstreamPathTemplate": "/products/{productId}",
+      "UpstreamHttpMethod": [ "Put" ],
+      "QoSOptions": {
+        "ExceptionsAllowedBeforeBreaking": 3,
+        "DurationOfBreak": 10,
+        "TimeoutValue": 5000
+      },
+      "FileCacheOptions": { "TtlSeconds": 15 }
+    },
+    {
+      "DownstreamPathTemplate": "/api/products/{productId}",
+      "DownstreamScheme": "http",
+      "DownstreamHost": "products20161126090340.azurewebsites.net",
+      "DownstreamPort": 80,
+      "UpstreamPathTemplate": "/products/{productId}",
+      "UpstreamHttpMethod": [ "Delete" ],
+      "QoSOptions": {
+        "ExceptionsAllowedBeforeBreaking": 3,
+        "DurationOfBreak": 10,
+        "TimeoutValue": 5000
+      },
+      "FileCacheOptions": { "TtlSeconds": 15 }
+    },
+    {
+      "DownstreamPathTemplate": "/api/customers",
+      "DownstreamScheme": "http",
+      "DownstreamHost": "customers20161126090811.azurewebsites.net",
+      "DownstreamPort": 80,
+      "UpstreamPathTemplate": "/customers",
+      "UpstreamHttpMethod": [ "Get" ],
+      "QoSOptions": {
+        "ExceptionsAllowedBeforeBreaking": 3,
+        "DurationOfBreak": 10,
+        "TimeoutValue": 5000
+      },
+      "FileCacheOptions": { "TtlSeconds": 15 }
+    },
+    {
+      "DownstreamPathTemplate": "/api/customers/{customerId}",
+      "DownstreamScheme": "http",
+      "DownstreamHost": "customers20161126090811.azurewebsites.net",
+      "DownstreamPort": 80,
+      "UpstreamPathTemplate": "/customers/{customerId}",
+      "UpstreamHttpMethod": [ "Get" ],
+      "QoSOptions": {
+        "ExceptionsAllowedBeforeBreaking": 3,
+        "DurationOfBreak": 10,
+        "TimeoutValue": 5000
+      },
+      "FileCacheOptions": { "TtlSeconds": 15 }
+    },
+    {
+      "DownstreamPathTemplate": "/api/customers",
+      "DownstreamScheme": "http",
+      "DownstreamHost": "customers20161126090811.azurewebsites.net",
+      "DownstreamPort": 80,
+      "UpstreamPathTemplate": "/customers",
+      "UpstreamHttpMethod": [ "Post" ],
+      "QoSOptions": {
+        "ExceptionsAllowedBeforeBreaking": 3,
+        "DurationOfBreak": 10,
+        "TimeoutValue": 5000
+      },
+      "FileCacheOptions": { "TtlSeconds": 15 }
+    },
+    {
+      "DownstreamPathTemplate": "/api/customers/{customerId}",
+      "DownstreamScheme": "http",
+      "DownstreamHost": "customers20161126090811.azurewebsites.net",
+      "DownstreamPort": 80,
+      "UpstreamPathTemplate": "/customers/{customerId}",
+      "UpstreamHttpMethod": [ "Put" ],
+      "QoSOptions": {
+        "ExceptionsAllowedBeforeBreaking": 3,
+        "DurationOfBreak": 10,
+        "TimeoutValue": 5000
+      },
+      "FileCacheOptions": { "TtlSeconds": 15 }
+    },
+    {
+      "DownstreamPathTemplate": "/api/customers/{customerId}",
+      "DownstreamScheme": "http",
+      "DownstreamHost": "customers20161126090811.azurewebsites.net",
+      "DownstreamPort": 80,
+      "UpstreamPathTemplate": "/customers/{customerId}",
+      "UpstreamHttpMethod": [ "Delete" ],
+      "QoSOptions": {
+        "ExceptionsAllowedBeforeBreaking": 3,
+        "DurationOfBreak": 10,
+        "TimeoutValue": 5000
+      },
+      "FileCacheOptions": { "TtlSeconds": 15 }
+    },
+    {
+      "DownstreamPathTemplate": "/posts",
+      "DownstreamScheme": "http",
+      "DownstreamHost": "jsonplaceholder.typicode.com",
+      "DownstreamPort": 80,
+      "UpstreamPathTemplate": "/posts/",
+      "UpstreamHttpMethod": [ "Get" ],
+      "QoSOptions": {
+        "ExceptionsAllowedBeforeBreaking": 3,
+        "DurationOfBreak": 10,
+        "TimeoutValue": 5000
+      },
+      "FileCacheOptions": { "TtlSeconds": 15 }
+    },
+    {
+      "DownstreamPathTemplate": "/",
+      "DownstreamScheme": "http",
+      "DownstreamHost": "www.bbc.co.uk",
+      "DownstreamPort": 80,
+      "UpstreamPathTemplate": "/bbc/",
+      "UpstreamHttpMethod": [ "Get" ],
+    }
+  ],
 
   "GlobalConfiguration": {
     "RequestIdKey": "OcRequestId",

--- a/test/Ocelot.UnitTests/Authentication/AuthenticationMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/Authentication/AuthenticationMiddlewareTests.cs
@@ -72,7 +72,7 @@ namespace Ocelot.UnitTests.Authentication
         public void should_call_next_middleware_if_route_is_not_authenticated()
         {
             this.Given(x => x.GivenTheDownStreamRouteIs(new DownstreamRoute(new List<UrlPathPlaceholderNameAndValue>(), new ReRouteBuilder()
-                                                                                                                            .WithUpstreamHttpMethod("Get")
+                                                                                                                            .WithUpstreamHttpMethod(new List<string> { "Get" })
                                                                                                                             .Build())))
                 .When(x => x.WhenICallTheMiddleware())
                 .Then(x => x.ThenTheUserIsAuthenticated())

--- a/test/Ocelot.UnitTests/Authorization/AuthorisationMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/Authorization/AuthorisationMiddlewareTests.cs
@@ -66,7 +66,7 @@ namespace Ocelot.UnitTests.Authorization
             this.Given(x => x.GivenTheDownStreamRouteIs(new DownstreamRoute(new List<UrlPathPlaceholderNameAndValue>(), 
                 new ReRouteBuilder()
                     .WithIsAuthorised(true)
-                    .WithUpstreamHttpMethod("Get")                                                                                                                                                                    .WithUpstreamHttpMethod("Get")
+                    .WithUpstreamHttpMethod(new List<string> { "Get" })
                     .Build())))
                 .And(x => x.GivenTheAuthServiceReturns(new OkResponse<bool>(true)))
                 .When(x => x.WhenICallTheMiddleware())

--- a/test/Ocelot.UnitTests/Cache/OutputCacheMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/Cache/OutputCacheMiddlewareTests.cs
@@ -91,7 +91,7 @@ namespace Ocelot.UnitTests.Cache
             var reRoute = new ReRouteBuilder()
                 .WithIsCached(true)
                 .WithCacheOptions(new CacheOptions(100))
-                .WithUpstreamHttpMethod("Get")
+                .WithUpstreamHttpMethod(new List<string> { "Get" })
                 .Build();
                 
             var downstreamRoute = new DownstreamRoute(new List<UrlPathPlaceholderNameAndValue>(), reRoute);

--- a/test/Ocelot.UnitTests/Claims/ClaimsBuilderMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/Claims/ClaimsBuilderMiddlewareTests.cs
@@ -72,7 +72,7 @@ namespace Ocelot.UnitTests.Claims
                     {
                         new ClaimToThing("sub", "UserType", "|", 0)
                     })
-                    .WithUpstreamHttpMethod("Get")
+                    .WithUpstreamHttpMethod(new List<string> { "Get" })
                     .Build());
 
             this.Given(x => x.GivenTheDownStreamRouteIs(downstreamRoute))

--- a/test/Ocelot.UnitTests/Configuration/FileConfigurationCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/FileConfigurationCreatorTests.cs
@@ -84,7 +84,7 @@ namespace Ocelot.UnitTests.Configuration
                                     DownstreamHost = "127.0.0.1",
                                     UpstreamPathTemplate = "/api/products/{productId}",
                                     DownstreamPathTemplate = "/products/{productId}",
-                                    UpstreamHttpMethod = "Get",
+                                    UpstreamHttpMethod = new List<string> { "Get" },
                                 }
                             },
             }))
@@ -117,7 +117,7 @@ namespace Ocelot.UnitTests.Configuration
                         DownstreamHost = "127.0.0.1",
                         UpstreamPathTemplate = "/api/products/{productId}",
                         DownstreamPathTemplate = "/products/{productId}",
-                        UpstreamHttpMethod = "Get",
+                        UpstreamHttpMethod = new List<string> { "Get" },
                         QoSOptions = new FileQoSOptions
                         {
                             TimeoutValue = 1,
@@ -153,7 +153,7 @@ namespace Ocelot.UnitTests.Configuration
                                         DownstreamHost = "127.0.0.1",
                                         UpstreamPathTemplate = "/api/products/{productId}",
                                         DownstreamPathTemplate = "/products/{productId}",
-                                        UpstreamHttpMethod = "Get",
+                                        UpstreamHttpMethod = new List<string> { "Get" },
                                     }
                                 },
                             }))
@@ -181,7 +181,7 @@ namespace Ocelot.UnitTests.Configuration
                                     DownstreamHost = "127.0.0.1",
                                     UpstreamPathTemplate = "/api/products/{productId}",
                                     DownstreamPathTemplate = "/products/{productId}",
-                                    UpstreamHttpMethod = "Get",
+                                    UpstreamHttpMethod = new List<string> { "Get" },
                                 }
                             },
                         }))
@@ -194,7 +194,7 @@ namespace Ocelot.UnitTests.Configuration
                                     .WithDownstreamHost("127.0.0.1")
                                     .WithDownstreamPathTemplate("/products/{productId}")
                                     .WithUpstreamPathTemplate("/api/products/{productId}")
-                                    .WithUpstreamHttpMethod("Get")
+                                    .WithUpstreamHttpMethod(new List<string> { "Get" })
                                     .Build()
                             }))
                 .BDDfy();
@@ -215,7 +215,7 @@ namespace Ocelot.UnitTests.Configuration
                                                     DownstreamScheme = "https",
                                                     UpstreamPathTemplate = "/api/products/{productId}",
                                                     DownstreamPathTemplate = "/products/{productId}",
-                                                    UpstreamHttpMethod = "Get",
+                                                    UpstreamHttpMethod = new List<string> { "Get" },
                                                 }
                                             },
                                         }))
@@ -228,7 +228,7 @@ namespace Ocelot.UnitTests.Configuration
                                                     .WithDownstreamScheme("https")
                                                     .WithDownstreamPathTemplate("/products/{productId}")
                                                     .WithUpstreamPathTemplate("/api/products/{productId}")
-                                                    .WithUpstreamHttpMethod("Get")
+                                                    .WithUpstreamHttpMethod(new List<string> { "Get" })
                                                     .Build()
                                             }))
                                 .BDDfy();
@@ -248,7 +248,7 @@ namespace Ocelot.UnitTests.Configuration
                                 {
                                     UpstreamPathTemplate = "/api/products/{productId}",
                                     DownstreamPathTemplate = "/products/{productId}",
-                                    UpstreamHttpMethod = "Get",
+                                    UpstreamHttpMethod = new List<string> { "Get" },
                                     ReRouteIsCaseSensitive = false,
                                     ServiceName = "ProductService"
                                 }
@@ -270,7 +270,7 @@ namespace Ocelot.UnitTests.Configuration
                                 new ReRouteBuilder()
                                     .WithDownstreamPathTemplate("/products/{productId}")
                                     .WithUpstreamPathTemplate("/api/products/{productId}")
-                                    .WithUpstreamHttpMethod("Get")
+                                    .WithUpstreamHttpMethod(new List<string> { "Get" })
                                     .WithServiceProviderConfiguraion(new ServiceProviderConfigurationBuilder()
                                         .WithUseServiceDiscovery(true)
                                         .WithServiceDiscoveryProvider("consul")
@@ -296,7 +296,7 @@ namespace Ocelot.UnitTests.Configuration
                                 {
                                     UpstreamPathTemplate = "/api/products/{productId}",
                                     DownstreamPathTemplate = "/products/{productId}",
-                                    UpstreamHttpMethod = "Get",
+                                    UpstreamHttpMethod = new List<string> { "Get" },
                                     ReRouteIsCaseSensitive = false,
                                 }
                             }
@@ -309,7 +309,7 @@ namespace Ocelot.UnitTests.Configuration
                                 new ReRouteBuilder()
                                     .WithDownstreamPathTemplate("/products/{productId}")
                                     .WithUpstreamPathTemplate("/api/products/{productId}")
-                                    .WithUpstreamHttpMethod("Get")
+                                    .WithUpstreamHttpMethod(new List<string> { "Get" })
                                     .WithServiceProviderConfiguraion(new ServiceProviderConfigurationBuilder()
                                         .WithUseServiceDiscovery(false)
                                         .Build())
@@ -332,7 +332,7 @@ namespace Ocelot.UnitTests.Configuration
                     {
                         UpstreamPathTemplate = "/api/products/{productId}",
                         DownstreamPathTemplate = "/products/{productId}",
-                        UpstreamHttpMethod = "Get",
+                        UpstreamHttpMethod = new List<string> { "Get" },
                         ReRouteIsCaseSensitive = false
                     }
                 }
@@ -346,7 +346,7 @@ namespace Ocelot.UnitTests.Configuration
                     new ReRouteBuilder()
                         .WithDownstreamPathTemplate("/products/{productId}")
                         .WithUpstreamPathTemplate("/api/products/{productId}")
-                        .WithUpstreamHttpMethod("Get")
+                        .WithUpstreamHttpMethod(new List<string> { "Get" })
                         .WithUpstreamTemplatePattern("(?i)/api/products/.*/$")
                         .Build()
                 }))
@@ -367,7 +367,7 @@ namespace Ocelot.UnitTests.Configuration
                     {
                         UpstreamPathTemplate = "/api/products/{productId}",
                         DownstreamPathTemplate = "/products/{productId}",
-                        UpstreamHttpMethod = "Get",
+                        UpstreamHttpMethod = new List<string> { "Get" },
                         ReRouteIsCaseSensitive = true
                     }
                 },
@@ -385,7 +385,7 @@ namespace Ocelot.UnitTests.Configuration
                     new ReRouteBuilder()
                         .WithDownstreamPathTemplate("/products/{productId}")
                         .WithUpstreamPathTemplate("/api/products/{productId}")
-                        .WithUpstreamHttpMethod("Get")
+                        .WithUpstreamHttpMethod(new List<string> { "Get" })
                         .WithRequestIdKey("blahhhh")
                         .Build()
                 }))
@@ -414,7 +414,7 @@ namespace Ocelot.UnitTests.Configuration
                 new ReRouteBuilder()
                     .WithDownstreamPathTemplate("/products/{productId}")
                     .WithUpstreamPathTemplate("/api/products/{productId}")
-                    .WithUpstreamHttpMethod("Get")
+                    .WithUpstreamHttpMethod(new List<string> { "Get" })
                     .WithAuthenticationOptions(authenticationOptions)
                     .WithClaimsToHeaders(new List<ClaimToThing>
                     {
@@ -431,7 +431,7 @@ namespace Ocelot.UnitTests.Configuration
                     {
                         UpstreamPathTemplate = "/api/products/{productId}",
                         DownstreamPathTemplate = "/products/{productId}",
-                        UpstreamHttpMethod = "Get",
+                        UpstreamHttpMethod = new List<string> { "Get" },
                         ReRouteIsCaseSensitive = true,
                         AuthenticationOptions = new FileAuthenticationOptions
                             {
@@ -482,7 +482,7 @@ namespace Ocelot.UnitTests.Configuration
                 new ReRouteBuilder()
                     .WithDownstreamPathTemplate("/products/{productId}")
                     .WithUpstreamPathTemplate("/api/products/{productId}")
-                    .WithUpstreamHttpMethod("Get")
+                    .WithUpstreamHttpMethod(new List<string> { "Get" })
                     .WithAuthenticationOptions(authenticationOptions)
                     .Build()
             };
@@ -495,7 +495,7 @@ namespace Ocelot.UnitTests.Configuration
                     {
                         UpstreamPathTemplate = "/api/products/{productId}",
                         DownstreamPathTemplate = "/products/{productId}",
-                        UpstreamHttpMethod = "Get",
+                        UpstreamHttpMethod = new List<string> { "Get" },
                         ReRouteIsCaseSensitive = true,
                         AuthenticationOptions = new FileAuthenticationOptions
                             {

--- a/test/Ocelot.UnitTests/Configuration/InMemoryConfigurationRepositoryTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/InMemoryConfigurationRepositoryTests.cs
@@ -87,7 +87,7 @@ namespace Ocelot.UnitTests.Configuration
             {
                 new ReRouteBuilder()
                 .WithDownstreamPathTemplate(_downstreamTemplatePath)
-                .WithUpstreamHttpMethod("Get")
+                .WithUpstreamHttpMethod(new List<string> { "Get" })
                 .Build()
             };
 

--- a/test/Ocelot.UnitTests/DownstreamRouteFinder/DownstreamRouteFinderMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/DownstreamRouteFinder/DownstreamRouteFinderMiddlewareTests.cs
@@ -66,7 +66,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
                     new List<UrlPathPlaceholderNameAndValue>(), 
                     new ReRouteBuilder()
                         .WithDownstreamPathTemplate("any old string")
-                        .WithUpstreamHttpMethod("Get")
+                        .WithUpstreamHttpMethod(new List<string> { "Get" })
                         .Build())))
                 .When(x => x.WhenICallTheMiddleware())
                 .Then(x => x.ThenTheScopedDataRepositoryIsCalledCorrectly())

--- a/test/Ocelot.UnitTests/DownstreamRouteFinder/DownstreamRouteFinderTests.cs
+++ b/test/Ocelot.UnitTests/DownstreamRouteFinder/DownstreamRouteFinderTests.cs
@@ -157,6 +157,95 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
                  .BDDfy();
         }
 
+        [Fact]
+        public void should_return_correct_route_for_http_verb_setting_multiple_upstream_http_method()
+        {
+            this.Given(x => x.GivenThereIsAnUpstreamUrlPath("someUpstreamPath"))
+                .And(
+                    x =>
+                        x.GivenTheTemplateVariableAndNameFinderReturns(
+                            new OkResponse<List<UrlPathPlaceholderNameAndValue>>(new List<UrlPathPlaceholderNameAndValue>())))
+                .And(x => x.GivenTheConfigurationIs(new List<ReRoute>
+                {
+                    new ReRouteBuilder()
+                        .WithDownstreamPathTemplate("someDownstreamPath")
+                        .WithUpstreamPathTemplate("someUpstreamPath")
+                        .WithUpstreamHttpMethod("Get, Post")
+                        .WithUpstreamTemplatePattern("")
+                        .Build()
+                }, string.Empty
+                    ))
+                .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
+                .And(x => x.GivenTheUpstreamHttpMethodIs("Post"))
+                .When(x => x.WhenICallTheFinder())
+                .Then(
+                    x => x.ThenTheFollowingIsReturned(new DownstreamRoute(new List<UrlPathPlaceholderNameAndValue>(),
+                        new ReRouteBuilder()
+                            .WithDownstreamPathTemplate("someDownstreamPath")
+                            .WithUpstreamHttpMethod("Post")
+                            .Build()
+                        )))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_return_correct_route_for_http_verb_setting_all_upstream_http_method()
+        {
+            this.Given(x => x.GivenThereIsAnUpstreamUrlPath("someUpstreamPath"))
+                .And(
+                    x =>
+                        x.GivenTheTemplateVariableAndNameFinderReturns(
+                            new OkResponse<List<UrlPathPlaceholderNameAndValue>>(new List<UrlPathPlaceholderNameAndValue>())))
+                .And(x => x.GivenTheConfigurationIs(new List<ReRoute>
+                {
+                    new ReRouteBuilder()
+                        .WithDownstreamPathTemplate("someDownstreamPath")
+                        .WithUpstreamPathTemplate("someUpstreamPath")
+                        .WithUpstreamHttpMethod("")
+                        .WithUpstreamTemplatePattern("")
+                        .Build()
+                }, string.Empty
+                    ))
+                .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
+                .And(x => x.GivenTheUpstreamHttpMethodIs("Post"))
+                .When(x => x.WhenICallTheFinder())
+                .Then(
+                    x => x.ThenTheFollowingIsReturned(new DownstreamRoute(new List<UrlPathPlaceholderNameAndValue>(),
+                        new ReRouteBuilder()
+                            .WithDownstreamPathTemplate("someDownstreamPath")
+                            .WithUpstreamHttpMethod("Post")
+                            .Build()
+                        )))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_not_return_route_for_http_verb_not_setting_in_upstream_http_method()
+        {
+            this.Given(x => x.GivenThereIsAnUpstreamUrlPath("someUpstreamPath"))
+                .And(
+                    x =>
+                        x.GivenTheTemplateVariableAndNameFinderReturns(
+                            new OkResponse<List<UrlPathPlaceholderNameAndValue>>(new List<UrlPathPlaceholderNameAndValue>())))
+                .And(x => x.GivenTheConfigurationIs(new List<ReRoute>
+                {
+                    new ReRouteBuilder()
+                        .WithDownstreamPathTemplate("someDownstreamPath")
+                        .WithUpstreamPathTemplate("someUpstreamPath")
+                        .WithUpstreamHttpMethod("Get, Patch, Delete")
+                        .WithUpstreamTemplatePattern("")
+                        .Build()
+                }, string.Empty
+                    ))
+                .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
+                .And(x => x.GivenTheUpstreamHttpMethodIs("Post"))
+                .When(x => x.WhenICallTheFinder())
+                 .Then(
+                     x => x.ThenAnErrorResponseIsReturned())
+                 .And(x => x.ThenTheUrlMatcherIsNotCalled())
+                 .BDDfy();
+        }
+
         private void GivenTheTemplateVariableAndNameFinderReturns(Response<List<UrlPathPlaceholderNameAndValue>> response)
         {
             _finder

--- a/test/Ocelot.UnitTests/DownstreamRouteFinder/DownstreamRouteFinderTests.cs
+++ b/test/Ocelot.UnitTests/DownstreamRouteFinder/DownstreamRouteFinderTests.cs
@@ -45,7 +45,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
                     new ReRouteBuilder()
                         .WithDownstreamPathTemplate("someDownstreamPath")
                         .WithUpstreamPathTemplate("someUpstreamPath")
-                        .WithUpstreamHttpMethod("Get")
+                        .WithUpstreamHttpMethod(new List<string> { "Get" })
                         .WithUpstreamTemplatePattern("someUpstreamPath")
                         .Build()
                 }, string.Empty
@@ -58,7 +58,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
                             new List<UrlPathPlaceholderNameAndValue>(),
                             new ReRouteBuilder()
                                 .WithDownstreamPathTemplate("someDownstreamPath")
-                                .WithUpstreamHttpMethod("Get")
+                                .WithUpstreamHttpMethod(new List<string> { "Get" })
                                 .Build()
                 )))
                 .And(x => x.ThenTheUrlMatcherIsCalledCorrectly())
@@ -78,7 +78,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
                     new ReRouteBuilder()
                         .WithDownstreamPathTemplate("someDownstreamPath")
                         .WithUpstreamPathTemplate("someUpstreamPath")
-                        .WithUpstreamHttpMethod("Get")
+                        .WithUpstreamHttpMethod(new List<string> { "Get" })
                         .WithUpstreamTemplatePattern("someUpstreamPath")
                         .Build()
                 }, string.Empty
@@ -90,7 +90,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
                     x => x.ThenTheFollowingIsReturned(new DownstreamRoute(new List<UrlPathPlaceholderNameAndValue>(),
                         new ReRouteBuilder()
                             .WithDownstreamPathTemplate("someDownstreamPath")
-                            .WithUpstreamHttpMethod("Get")
+                            .WithUpstreamHttpMethod(new List<string> { "Get" })
                             .Build()
                         )))
                 .And(x => x.ThenTheUrlMatcherIsNotCalled())
@@ -110,13 +110,13 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
                     new ReRouteBuilder()
                         .WithDownstreamPathTemplate("someDownstreamPath")
                         .WithUpstreamPathTemplate("someUpstreamPath")
-                        .WithUpstreamHttpMethod("Get")
+                        .WithUpstreamHttpMethod(new List<string> { "Get" })
                         .WithUpstreamTemplatePattern("")
                         .Build(),
                     new ReRouteBuilder()
                         .WithDownstreamPathTemplate("someDownstreamPathForAPost")
                         .WithUpstreamPathTemplate("someUpstreamPath")
-                        .WithUpstreamHttpMethod("Post")
+                        .WithUpstreamHttpMethod(new List<string> { "Post" })
                         .WithUpstreamTemplatePattern("")
                         .Build()
                 }, string.Empty
@@ -128,7 +128,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
                     x => x.ThenTheFollowingIsReturned(new DownstreamRoute(new List<UrlPathPlaceholderNameAndValue>(),
                         new ReRouteBuilder()
                             .WithDownstreamPathTemplate("someDownstreamPathForAPost")
-                            .WithUpstreamHttpMethod("Post")
+                            .WithUpstreamHttpMethod(new List<string> { "Post" })
                             .Build()
                         )))
                 .BDDfy();
@@ -143,7 +143,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
                         new ReRouteBuilder()
                         .WithDownstreamPathTemplate("somPath")
                         .WithUpstreamPathTemplate("somePath")
-                        .WithUpstreamHttpMethod("Get")
+                        .WithUpstreamHttpMethod(new List<string> { "Get" })
                         .WithUpstreamTemplatePattern("somePath")
                         .Build(),   
                      }, string.Empty
@@ -170,7 +170,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
                     new ReRouteBuilder()
                         .WithDownstreamPathTemplate("someDownstreamPath")
                         .WithUpstreamPathTemplate("someUpstreamPath")
-                        .WithUpstreamHttpMethod("Get, Post")
+                        .WithUpstreamHttpMethod(new List<string> { "Get", "Post" })
                         .WithUpstreamTemplatePattern("")
                         .Build()
                 }, string.Empty
@@ -182,7 +182,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
                     x => x.ThenTheFollowingIsReturned(new DownstreamRoute(new List<UrlPathPlaceholderNameAndValue>(),
                         new ReRouteBuilder()
                             .WithDownstreamPathTemplate("someDownstreamPath")
-                            .WithUpstreamHttpMethod("Post")
+                            .WithUpstreamHttpMethod(new List<string> { "Post" })
                             .Build()
                         )))
                 .BDDfy();
@@ -201,7 +201,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
                     new ReRouteBuilder()
                         .WithDownstreamPathTemplate("someDownstreamPath")
                         .WithUpstreamPathTemplate("someUpstreamPath")
-                        .WithUpstreamHttpMethod("")
+                        .WithUpstreamHttpMethod(new List<string>())
                         .WithUpstreamTemplatePattern("")
                         .Build()
                 }, string.Empty
@@ -213,7 +213,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
                     x => x.ThenTheFollowingIsReturned(new DownstreamRoute(new List<UrlPathPlaceholderNameAndValue>(),
                         new ReRouteBuilder()
                             .WithDownstreamPathTemplate("someDownstreamPath")
-                            .WithUpstreamHttpMethod("Post")
+                            .WithUpstreamHttpMethod(new List<string> { "Post" })
                             .Build()
                         )))
                 .BDDfy();
@@ -232,7 +232,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
                     new ReRouteBuilder()
                         .WithDownstreamPathTemplate("someDownstreamPath")
                         .WithUpstreamPathTemplate("someUpstreamPath")
-                        .WithUpstreamHttpMethod("Get, Patch, Delete")
+                        .WithUpstreamHttpMethod(new List<string> { "Get", "Patch", "Delete" })
                         .WithUpstreamTemplatePattern("")
                         .Build()
                 }, string.Empty

--- a/test/Ocelot.UnitTests/DownstreamUrlCreator/DownstreamUrlCreatorMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/DownstreamUrlCreator/DownstreamUrlCreatorMiddlewareTests.cs
@@ -78,7 +78,7 @@ namespace Ocelot.UnitTests.DownstreamUrlCreator
                     new List<UrlPathPlaceholderNameAndValue>(), 
                     new ReRouteBuilder()
                         .WithDownstreamPathTemplate("any old string")
-                        .WithUpstreamHttpMethod("Get")
+                        .WithUpstreamHttpMethod(new List<string> { "Get" })
                         .WithDownstreamScheme("https")
                         .Build())))
                 .And(x => x.GivenTheDownstreamRequestUriIs("http://my.url/abc?q=123"))

--- a/test/Ocelot.UnitTests/DownstreamUrlCreator/UrlTemplateReplacer/UpstreamUrlPathTemplateVariableReplacerTests.cs
+++ b/test/Ocelot.UnitTests/DownstreamUrlCreator/UrlTemplateReplacer/UpstreamUrlPathTemplateVariableReplacerTests.cs
@@ -29,7 +29,7 @@ namespace Ocelot.UnitTests.DownstreamUrlCreator.UrlTemplateReplacer
                 new DownstreamRoute(
                     new List<UrlPathPlaceholderNameAndValue>(), 
                     new ReRouteBuilder()
-                        .WithUpstreamHttpMethod("Get")
+                        .WithUpstreamHttpMethod(new List<string> { "Get" })
                         .Build())))
                 .When(x => x.WhenIReplaceTheTemplateVariables())
                 .Then(x => x.ThenTheDownstreamUrlPathIsReturned(""))
@@ -44,7 +44,7 @@ namespace Ocelot.UnitTests.DownstreamUrlCreator.UrlTemplateReplacer
                 new List<UrlPathPlaceholderNameAndValue>(), 
                 new ReRouteBuilder()
                     .WithDownstreamPathTemplate("/")
-                    .WithUpstreamHttpMethod("Get")
+                    .WithUpstreamHttpMethod(new List<string> { "Get" })
                     .Build())))
                 .When(x => x.WhenIReplaceTheTemplateVariables())
                 .Then(x => x.ThenTheDownstreamUrlPathIsReturned("/"))
@@ -57,7 +57,7 @@ namespace Ocelot.UnitTests.DownstreamUrlCreator.UrlTemplateReplacer
             this.Given(x => x.GivenThereIsAUrlMatch(new DownstreamRoute(new List<UrlPathPlaceholderNameAndValue>(), 
                 new ReRouteBuilder()
                     .WithDownstreamPathTemplate("api")
-                    .WithUpstreamHttpMethod("Get")
+                    .WithUpstreamHttpMethod(new List<string> { "Get" })
                     .Build())))
                 .When(x => x.WhenIReplaceTheTemplateVariables())
                 .Then(x => x.ThenTheDownstreamUrlPathIsReturned("api"))
@@ -70,7 +70,7 @@ namespace Ocelot.UnitTests.DownstreamUrlCreator.UrlTemplateReplacer
             this.Given(x => x.GivenThereIsAUrlMatch(new DownstreamRoute(new List<UrlPathPlaceholderNameAndValue>(), 
                 new ReRouteBuilder()
                     .WithDownstreamPathTemplate("api/")
-                    .WithUpstreamHttpMethod("Get")
+                    .WithUpstreamHttpMethod(new List<string> { "Get" })
                     .Build())))
                 .When(x => x.WhenIReplaceTheTemplateVariables())
                 .Then(x => x.ThenTheDownstreamUrlPathIsReturned("api/"))
@@ -83,7 +83,7 @@ namespace Ocelot.UnitTests.DownstreamUrlCreator.UrlTemplateReplacer
             this.Given(x => x.GivenThereIsAUrlMatch(new DownstreamRoute(new List<UrlPathPlaceholderNameAndValue>(), 
                 new ReRouteBuilder()
                     .WithDownstreamPathTemplate("api/product/products/")
-                    .WithUpstreamHttpMethod("Get")
+                    .WithUpstreamHttpMethod(new List<string> { "Get" })
                     .Build())))
                 .When(x => x.WhenIReplaceTheTemplateVariables())
                 .Then(x => x.ThenTheDownstreamUrlPathIsReturned("api/product/products/"))
@@ -101,7 +101,7 @@ namespace Ocelot.UnitTests.DownstreamUrlCreator.UrlTemplateReplacer
             this.Given(x => x.GivenThereIsAUrlMatch(new DownstreamRoute(templateVariables, 
                 new ReRouteBuilder()
                     .WithDownstreamPathTemplate("productservice/products/{productId}/")
-                    .WithUpstreamHttpMethod("Get")
+                    .WithUpstreamHttpMethod(new List<string> { "Get" })
                     .Build())))
              .When(x => x.WhenIReplaceTheTemplateVariables())
              .Then(x => x.ThenTheDownstreamUrlPathIsReturned("productservice/products/1/"))
@@ -119,7 +119,7 @@ namespace Ocelot.UnitTests.DownstreamUrlCreator.UrlTemplateReplacer
             this.Given(x => x.GivenThereIsAUrlMatch(new DownstreamRoute(templateVariables, 
                 new ReRouteBuilder()
                     .WithDownstreamPathTemplate("productservice/products/{productId}/variants")
-                    .WithUpstreamHttpMethod("Get")
+                    .WithUpstreamHttpMethod(new List<string> { "Get" })
                     .Build())))
              .When(x => x.WhenIReplaceTheTemplateVariables())
              .Then(x => x.ThenTheDownstreamUrlPathIsReturned("productservice/products/1/variants"))
@@ -138,7 +138,7 @@ namespace Ocelot.UnitTests.DownstreamUrlCreator.UrlTemplateReplacer
             this.Given(x => x.GivenThereIsAUrlMatch(new DownstreamRoute(templateVariables, 
                 new ReRouteBuilder()
                     .WithDownstreamPathTemplate("productservice/products/{productId}/variants/{variantId}")
-                    .WithUpstreamHttpMethod("Get")
+                    .WithUpstreamHttpMethod(new List<string> { "Get" })
                     .Build())))
              .When(x => x.WhenIReplaceTheTemplateVariables())
              .Then(x => x.ThenTheDownstreamUrlPathIsReturned("productservice/products/1/variants/12"))
@@ -158,7 +158,7 @@ namespace Ocelot.UnitTests.DownstreamUrlCreator.UrlTemplateReplacer
             this.Given(x => x.GivenThereIsAUrlMatch(new DownstreamRoute(templateVariables, 
                 new ReRouteBuilder()
                 .WithDownstreamPathTemplate("productservice/category/{categoryId}/products/{productId}/variants/{variantId}")
-                .WithUpstreamHttpMethod("Get")
+                .WithUpstreamHttpMethod(new List<string> { "Get" })
                 .Build())))
              .When(x => x.WhenIReplaceTheTemplateVariables())
              .Then(x => x.ThenTheDownstreamUrlPathIsReturned("productservice/category/34/products/1/variants/12"))

--- a/test/Ocelot.UnitTests/Headers/HttpRequestHeadersBuilderMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/Headers/HttpRequestHeadersBuilderMiddlewareTests.cs
@@ -76,7 +76,7 @@ namespace Ocelot.UnitTests.Headers
                     {
                         new ClaimToThing("UserId", "Subject", "", 0)
                     })
-                    .WithUpstreamHttpMethod("Get")
+                    .WithUpstreamHttpMethod(new List<string> { "Get" })
                     .Build());
 
             this.Given(x => x.GivenTheDownStreamRouteIs(downstreamRoute))

--- a/test/Ocelot.UnitTests/LoadBalancer/LoadBalancerFactoryTests.cs
+++ b/test/Ocelot.UnitTests/LoadBalancer/LoadBalancerFactoryTests.cs
@@ -4,6 +4,7 @@ using Ocelot.Configuration.Builder;
 using Ocelot.LoadBalancer.LoadBalancers;
 using Ocelot.ServiceDiscovery;
 using Shouldly;
+using System.Collections.Generic;
 using TestStack.BDDfy;
 using Xunit;
 
@@ -29,7 +30,7 @@ namespace Ocelot.UnitTests.LoadBalancer
         {
             var reRoute = new ReRouteBuilder()
                 .WithServiceProviderConfiguraion(new ServiceProviderConfigurationBuilder().Build())
-                .WithUpstreamHttpMethod("Get")
+                .WithUpstreamHttpMethod(new List<string> { "Get" })
                 .Build();
 
             this.Given(x => x.GivenAReRoute(reRoute))
@@ -44,7 +45,7 @@ namespace Ocelot.UnitTests.LoadBalancer
         {
              var reRoute = new ReRouteBuilder()
                 .WithLoadBalancer("RoundRobin")
-                .WithUpstreamHttpMethod("Get")
+                .WithUpstreamHttpMethod(new List<string> { "Get" })
                 .WithServiceProviderConfiguraion(new ServiceProviderConfigurationBuilder().Build())
                 .Build();
 
@@ -60,7 +61,7 @@ namespace Ocelot.UnitTests.LoadBalancer
         {
              var reRoute = new ReRouteBuilder()
                 .WithLoadBalancer("LeastConnection")
-                .WithUpstreamHttpMethod("Get")
+                .WithUpstreamHttpMethod(new List<string> { "Get" })
                 .WithServiceProviderConfiguraion(new ServiceProviderConfigurationBuilder().Build())
                 .Build();
 
@@ -76,7 +77,7 @@ namespace Ocelot.UnitTests.LoadBalancer
         {
             var reRoute = new ReRouteBuilder()
                 .WithLoadBalancer("RoundRobin")
-                .WithUpstreamHttpMethod("Get")
+                .WithUpstreamHttpMethod(new List<string> { "Get" })
                 .WithServiceProviderConfiguraion(new ServiceProviderConfigurationBuilder().Build())
                 .Build();
 

--- a/test/Ocelot.UnitTests/LoadBalancer/LoadBalancerMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/LoadBalancer/LoadBalancerMiddlewareTests.cs
@@ -73,7 +73,7 @@ namespace Ocelot.UnitTests.LoadBalancer
         {
             var downstreamRoute = new DownstreamRoute(new List<Ocelot.DownstreamRouteFinder.UrlMatcher.UrlPathPlaceholderNameAndValue>(),
                 new ReRouteBuilder()
-                    .WithUpstreamHttpMethod("Get")
+                    .WithUpstreamHttpMethod(new List<string> { "Get" })
                     .Build());
 
             this.Given(x => x.GivenTheDownStreamUrlIs("http://my.url/abc?q=123"))
@@ -90,7 +90,7 @@ namespace Ocelot.UnitTests.LoadBalancer
         {         
             var downstreamRoute = new DownstreamRoute(new List<Ocelot.DownstreamRouteFinder.UrlMatcher.UrlPathPlaceholderNameAndValue>(),
                 new ReRouteBuilder()
-                    .WithUpstreamHttpMethod("Get")
+                    .WithUpstreamHttpMethod(new List<string> { "Get" })
                     .Build());
 
             this.Given(x => x.GivenTheDownStreamUrlIs("http://my.url/abc?q=123"))
@@ -106,7 +106,7 @@ namespace Ocelot.UnitTests.LoadBalancer
         {
             var downstreamRoute = new DownstreamRoute(new List<Ocelot.DownstreamRouteFinder.UrlMatcher.UrlPathPlaceholderNameAndValue>(),
                 new ReRouteBuilder()
-                    .WithUpstreamHttpMethod("Get")
+                    .WithUpstreamHttpMethod(new List<string> { "Get" })
                     .Build());
 
             this.Given(x => x.GivenTheDownStreamUrlIs("http://my.url/abc?q=123"))

--- a/test/Ocelot.UnitTests/QueryStrings/QueryStringBuilderMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/QueryStrings/QueryStringBuilderMiddlewareTests.cs
@@ -74,7 +74,7 @@ namespace Ocelot.UnitTests.QueryStrings
                     {
                         new ClaimToThing("UserId", "Subject", "", 0)
                     })
-                    .WithUpstreamHttpMethod("Get")
+                    .WithUpstreamHttpMethod(new List<string> { "Get" })
                     .Build());
 
             this.Given(x => x.GivenTheDownStreamRouteIs(downstreamRoute))

--- a/test/Ocelot.UnitTests/RateLimit/ClientRateLimitMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/RateLimit/ClientRateLimitMiddlewareTests.cs
@@ -72,7 +72,7 @@ namespace Ocelot.UnitTests.RateLimit
             var downstreamRoute = new DownstreamRoute(new List<Ocelot.DownstreamRouteFinder.UrlMatcher.UrlPathPlaceholderNameAndValue>(),
                  new ReRouteBuilder().WithEnableRateLimiting(true).WithRateLimitOptions(
                      new Ocelot.Configuration.RateLimitOptions(true, "ClientId", new List<string>(), false, "", "", new Ocelot.Configuration.RateLimitRule("1s", 100, 3), 429))
-                     .WithUpstreamHttpMethod("Get")
+                     .WithUpstreamHttpMethod(new List<string> { "Get" })
                      .Build());
 
             this.Given(x => x.GivenTheDownStreamRouteIs(downstreamRoute))
@@ -89,7 +89,7 @@ namespace Ocelot.UnitTests.RateLimit
             var downstreamRoute = new DownstreamRoute(new List<Ocelot.DownstreamRouteFinder.UrlMatcher.UrlPathPlaceholderNameAndValue>(),
                  new ReRouteBuilder().WithEnableRateLimiting(true).WithRateLimitOptions(
                      new Ocelot.Configuration.RateLimitOptions(true, "ClientId", new List<string>() { "ocelotclient2" }, false, "", "", new  RateLimitRule( "1s", 100,3),429))
-                     .WithUpstreamHttpMethod("Get")
+                     .WithUpstreamHttpMethod(new List<string> { "Get" })
                      .Build());
 
             this.Given(x => x.GivenTheDownStreamRouteIs(downstreamRoute))

--- a/test/Ocelot.UnitTests/Request/HttpRequestBuilderMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/Request/HttpRequestBuilderMiddlewareTests.cs
@@ -76,7 +76,7 @@ namespace Ocelot.UnitTests.Request
             var downstreamRoute = new DownstreamRoute(new List<UrlPathPlaceholderNameAndValue>(),
                 new ReRouteBuilder()
                     .WithRequestIdKey("LSRequestId")
-                    .WithUpstreamHttpMethod("Get")
+                    .WithUpstreamHttpMethod(new List<string> { "Get" })
                     .Build());
 
             this.Given(x => x.GivenTheDownStreamUrlIs("any old string"))

--- a/test/Ocelot.UnitTests/RequestId/RequestIdMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/RequestId/RequestIdMiddlewareTests.cs
@@ -78,7 +78,7 @@ namespace Ocelot.UnitTests.RequestId
                 new ReRouteBuilder()
                 .WithDownstreamPathTemplate("any old string")
                 .WithRequestIdKey("LSRequestId")
-                .WithUpstreamHttpMethod("Get")
+                .WithUpstreamHttpMethod(new List<string> { "Get" })
                 .Build());
 
             var requestId = Guid.NewGuid().ToString();
@@ -97,7 +97,7 @@ namespace Ocelot.UnitTests.RequestId
                 new ReRouteBuilder()
                 .WithDownstreamPathTemplate("any old string")
                 .WithRequestIdKey("LSRequestId")
-                .WithUpstreamHttpMethod("Get")
+                .WithUpstreamHttpMethod(new List<string> { "Get" })
                 .Build());
 
             this.Given(x => x.GivenTheDownStreamRouteIs(downstreamRoute))

--- a/test/Ocelot.UnitTests/Requester/QoSProviderFactoryTests.cs
+++ b/test/Ocelot.UnitTests/Requester/QoSProviderFactoryTests.cs
@@ -4,6 +4,7 @@ using Ocelot.Configuration.Builder;
 using Ocelot.Logging;
 using Ocelot.Requester.QoS;
 using Shouldly;
+using System.Collections.Generic;
 using TestStack.BDDfy;
 using Xunit;
 
@@ -31,7 +32,7 @@ namespace Ocelot.UnitTests.Requester
         public void should_return_no_qos_provider()
         {
             var reRoute = new ReRouteBuilder()
-                .WithUpstreamHttpMethod("get")
+                .WithUpstreamHttpMethod(new List<string> { "get" })
                 .WithIsQos(false)
                 .Build();
 
@@ -51,7 +52,7 @@ namespace Ocelot.UnitTests.Requester
                 .Build();
 
             var reRoute = new ReRouteBuilder()
-               .WithUpstreamHttpMethod("get")
+               .WithUpstreamHttpMethod(new List<string> { "get" })
                .WithIsQos(true)
                .WithQosOptions(qosOptions)
                .Build();


### PR DESCRIPTION
Hi,

I did a little change in the code to allow the possibility of set multiple verbs in the UpstreamHttpMethod.

@hanyubao commented about this in #91 and I think it´s a good idea in order to simplify the "configuration.json" file and don´t need to map each http verb for each controller.

For example, to allow access to a controller only for the Get, Post and Put http verbs can use:


```
{
"DownstreamPathTemplate": "/api/{controller}",
"DownstreamScheme": "http",
"DownstreamHost": "mydomain.com",
"DownstreamPort": 80,
"UpstreamPathTemplate": "/api/webapi1/{controller}",
"UpstreamHttpMethod": "Get, Post, Put"
}
```

this only allow access to the controller for Get, Post and Put requests (but not Delete, Patch, ...). Other possibility it´s set a empty string for UpstreamHttpMethod. This mean that you allow the access to any http verb:

```
{
"DownstreamPathTemplate": "/api/{controller}",
"DownstreamScheme": "http",
"DownstreamHost": "mydomain.com",
"DownstreamPort": 80,
"UpstreamPathTemplate": "/api/webapi1/{controller}",
"UpstreamHttpMethod": ""
}
```


In this way, a "configuration.json" file like:

```
{
  "ReRoutes": [
    {
      "UpstreamPathTemplate": "/myApp1/api/{urlPath}",
      "UpstreamHttpMethod": "Get",
      "DownstreamPathTemplate": "/api/{urlPath}",
      "DownstreamScheme": "http",
      "DownstreamHost": "localhost",
      "DownstreamPort": 5101
    },
    {
      "UpstreamPathTemplate": "/myApp1/api/{urlPath}",
      "UpstreamHttpMethod": "Post",
      "DownstreamPathTemplate": "/api/{urlPath}",
      "DownstreamScheme": "http",
      "DownstreamHost": "localhost",
      "DownstreamPort": 5101
    },
    {
      "UpstreamPathTemplate": "/myApp1/api/{urlPath}",
      "UpstreamHttpMethod": "Put",
      "DownstreamPathTemplate": "/api/{urlPath}",
      "DownstreamScheme": "http",
      "DownstreamHost": "localhost",
      "DownstreamPort": 5101
    },
    {
      "UpstreamPathTemplate": "/myApp1/api/{urlPath}",
      "UpstreamHttpMethod": "Patch",
      "DownstreamPathTemplate": "/api/{urlPath}",
      "DownstreamScheme": "http",
      "DownstreamHost": "localhost",
      "DownstreamPort": 5101
    },
    {
      "UpstreamPathTemplate": "/myApp1/api/{urlPath}",
      "UpstreamHttpMethod": "Delete",
      "DownstreamPathTemplate": "/api/{urlPath}",
      "DownstreamScheme": "http",
      "DownstreamHost": "localhost",
      "DownstreamPort": 5101
    }
  ],

  "GlobalConfiguration": {
  }
}
```

can be simplified in:

```
{
  "ReRoutes": [
    {
      "UpstreamPathTemplate": "/myApp1/api/{urlPath}",
      "UpstreamHttpMethod": "Get, Post, Put, Patch, Delete",
      "DownstreamPathTemplate": "/api/{urlPath}",
      "DownstreamScheme": "http",
      "DownstreamHost": "localhost",
      "DownstreamPort": 5101
    }
  ],

  "GlobalConfiguration": {
  }
}
```

Implementation note: I made the change using the "UpstreamHttpMethod" property with the same type of data (string) because if I changed it to an array of strings, the configuration file of the users would not be compatible with this change and the users would need to update the configuration file if they want to use this version of the code.

Sorry if I have not been able to explain it well.
