### PR TITLE
Updated CharactersDontMatch method

### DIFF
--- a/src/Ocelot/DownstreamRouteFinder/UrlMatcher/UrlPathPlaceholderNameAndValueFinder.cs
+++ b/src/Ocelot/DownstreamRouteFinder/UrlMatcher/UrlPathPlaceholderNameAndValueFinder.cs
@@ -70,7 +70,7 @@ namespace Ocelot.DownstreamRouteFinder.UrlMatcher
 
         private bool CharactersDontMatch(char characterOne, char characterTwo)
         {
-            return characterOne != characterTwo;
+            return char.ToLower(characterOne) != char.ToLower(characterTwo);
         }
 
         private bool ContinueScanningUrl(int counterForUrl, int urlLength)


### PR DESCRIPTION
I should have done it in the PR #89 but I didn´t notice. Sorry.

At this point the comparer must ignore case sensitive. It´s important for the proper functioning.

