### PR TITLE
Fixes to get build running again on macOS. 

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -92,7 +92,7 @@ Task("Version")
 		if (AppVeyor.IsRunningOnAppVeyor)
 		{
 			Information("Persisting version number...");
-			PersistVersion(nugetVersion);
+			PersistVersion(committedVersion, nugetVersion);
 			buildVersion = nugetVersion;
 		}
 		else
@@ -229,7 +229,7 @@ Task("CreatePackages")
 		EnsureDirectoryExists(packagesDir);
 		CopyFiles("./src/**/Ocelot.*.nupkg", packagesDir);
 
-		GenerateReleaseNotes();
+		GenerateReleaseNotes(releaseNotesFile);
 
         System.IO.File.WriteAllLines(artifactsFile, new[]{
             "nuget:Ocelot." + buildVersion + ".nupkg",
@@ -251,9 +251,9 @@ Task("ReleasePackagesToUnstableFeed")
 	.IsDependentOn("CreatePackages")
 	.Does(() =>
 	{
-		if (ShouldPublishToUnstableFeed())
+		if (ShouldPublishToUnstableFeed(nugetFeedUnstableBranchFilter, versioning.BranchName))
 		{
-			PublishPackages(nugetFeedUnstableKey, nugetFeedUnstableUploadUrl, nugetFeedUnstableSymbolsUploadUrl);
+			PublishPackages(packagesDir, artifactsFile, nugetFeedUnstableKey, nugetFeedUnstableUploadUrl, nugetFeedUnstableSymbolsUploadUrl);
 		}
 	});
 
@@ -306,7 +306,7 @@ Task("ReleasePackagesToStableFeed")
     .IsDependentOn("DownloadGitHubReleaseArtifacts")
     .Does(() =>
     {
-		PublishPackages(nugetFeedStableKey, nugetFeedStableUploadUrl, nugetFeedStableSymbolsUploadUrl);
+		PublishPackages(packagesDir, artifactsFile, nugetFeedStableKey, nugetFeedStableUploadUrl, nugetFeedStableSymbolsUploadUrl);
     });
 
 Task("Release")
@@ -326,9 +326,9 @@ private GitVersion GetNuGetVersionForCommit()
 }
 
 /// Updates project version in all of our projects
-private void PersistVersion(string version)
+private void PersistVersion(string committedVersion, string newVersion)
 {
-	Information(string.Format("We'll search all csproj files for {0} and replace with {1}...", committedVersion, version));
+	Information(string.Format("We'll search all csproj files for {0} and replace with {1}...", committedVersion, newVersion));
 
 	var projectFiles = GetFiles("./**/*.csproj");
 
@@ -339,24 +339,30 @@ private void PersistVersion(string version)
 		Information(string.Format("Updating {0}...", file));
 
 		var updatedProjectFile = System.IO.File.ReadAllText(file)
-			.Replace(committedVersion, version);
+			.Replace(committedVersion, newVersion);
 
 		System.IO.File.WriteAllText(file, updatedProjectFile);
 	}
 }
 
 /// generates release notes based on issues closed in GitHub since the last release
-private void GenerateReleaseNotes()
+private void GenerateReleaseNotes(ConvertableFilePath file)
 {
-	Information("Generating release notes at " + releaseNotesFile);
+	if(!IsRunningOnWindows())
+	{
+        Warning("We are not running on Windows so we cannot generate release notes.");
+        return;		
+	}
+
+	Information("Generating release notes at " + file);
 
     var releaseNotesExitCode = StartProcess(
         @"tools/GitReleaseNotes/tools/gitreleasenotes.exe", 
-        new ProcessSettings { Arguments = ". /o " + releaseNotesFile });
+        new ProcessSettings { Arguments = ". /o " + file });
 
-    if (string.IsNullOrEmpty(System.IO.File.ReadAllText(releaseNotesFile)))
+    if (string.IsNullOrEmpty(System.IO.File.ReadAllText(file)))
 	{
-        System.IO.File.WriteAllText(releaseNotesFile, "No issues closed since last release");
+        System.IO.File.WriteAllText(file, "No issues closed since last release");
 	}
 
     if (releaseNotesExitCode != 0) 
@@ -366,7 +372,7 @@ private void GenerateReleaseNotes()
 }
 
 /// Publishes code and symbols packages to nuget feed, based on contents of artifacts file
-private void PublishPackages(string feedApiKey, string codeFeedUrl, string symbolFeedUrl)
+private void PublishPackages(ConvertableDirectoryPath packagesDir, ConvertableFilePath artifactsFile, string feedApiKey, string codeFeedUrl, string symbolFeedUrl)
 {
         var artifacts = System.IO.File
             .ReadAllLines(artifactsFile)
@@ -374,6 +380,8 @@ private void PublishPackages(string feedApiKey, string codeFeedUrl, string symbo
             .ToDictionary(v => v[0], v => v[1]);
 
 		var codePackage = packagesDir + File(artifacts["nuget"]);
+
+		Information("Pushing package " + codePackage);
 
         NuGetPush(
             codePackage,
@@ -401,17 +409,17 @@ private string GetResource(string url)
     }
 }
 
-private bool ShouldPublishToUnstableFeed()
+private bool ShouldPublishToUnstableFeed(string filter, string branchName)
 {
-	var regex = new System.Text.RegularExpressions.Regex(nugetFeedUnstableBranchFilter);
-	var publish = regex.IsMatch(versioning.BranchName);
+	var regex = new System.Text.RegularExpressions.Regex(filter);
+	var publish = regex.IsMatch(branchName);
 	if (publish)
 	{
-		Information("Branch " + versioning.BranchName + " will be published to the unstable feed");
+		Information("Branch " + branchName + " will be published to the unstable feed");
 	}
 	else
 	{
-		Information("Branch " + versioning.BranchName + " will not be published to the unstable feed");
+		Information("Branch " + branchName + " will not be published to the unstable feed");
 	}
 	return publish;	
 }


### PR DESCRIPTION
Basically, re-applying changes from #41 which were lost in efec217.

We need to be careful here, because I remember the original changes in #41 broke the release process. However, I think this should good as we're using ConvertableFilePath etc rather than string, which iirc is what the original problem was.

Integration tests failing for me on the mac, but I don't think that's anything to do with any of this.