### PR TITLE
Cookie proxying and auto redirect configuration #128

### DIFF
--- a/src/Ocelot/Configuration/Builder/ReRouteBuilder.cs
+++ b/src/Ocelot/Configuration/Builder/ReRouteBuilder.cs
@@ -29,6 +29,7 @@ namespace Ocelot.Configuration.Builder
         private ServiceProviderConfiguration _serviceProviderConfiguraion;
         private bool _useQos;
         private QoSOptions _qosOptions;
+        private HttpHandlerOptions _httpHandlerOptions;
         public bool _enableRateLimiting;
         public RateLimitOptions _rateLimitOptions;
 
@@ -176,6 +177,11 @@ namespace Ocelot.Configuration.Builder
             return this;
         }
 
+        public ReRouteBuilder WithHttpHandlerOptions(HttpHandlerOptions input)
+        {
+            _httpHandlerOptions = input;
+            return this;
+        }
 
         public ReRoute Build()
         {
@@ -203,7 +209,8 @@ namespace Ocelot.Configuration.Builder
                 _useQos, 
                 _qosOptions,
                 _enableRateLimiting,
-                _rateLimitOptions);
+                _rateLimitOptions,
+                _httpHandlerOptions);
         }
     }
 }

--- a/src/Ocelot/Configuration/Creator/FileOcelotConfigurationCreator.cs
+++ b/src/Ocelot/Configuration/Creator/FileOcelotConfigurationCreator.cs
@@ -38,6 +38,7 @@ namespace Ocelot.Configuration.Creator
         private readonly IReRouteOptionsCreator _fileReRouteOptionsCreator;
         private readonly IRateLimitOptionsCreator _rateLimitOptionsCreator;
         private readonly IRegionCreator _regionCreator;
+        private readonly IHttpHandlerOptionsCreator _httpHandlerOptionsCreator;
 
         public FileOcelotConfigurationCreator(
             IOptions<FileConfiguration> options, 
@@ -55,7 +56,8 @@ namespace Ocelot.Configuration.Creator
             IQoSOptionsCreator qosOptionsCreator,
             IReRouteOptionsCreator fileReRouteOptionsCreator,
             IRateLimitOptionsCreator rateLimitOptionsCreator,
-            IRegionCreator regionCreator
+            IRegionCreator regionCreator,
+            IHttpHandlerOptionsCreator httpHandlerOptionsCreator
             )
         {
             _regionCreator = regionCreator;
@@ -74,6 +76,7 @@ namespace Ocelot.Configuration.Creator
             _serviceProviderConfigCreator = serviceProviderConfigCreator;
             _qosOptionsCreator = qosOptionsCreator;
             _fileReRouteOptionsCreator = fileReRouteOptionsCreator;
+            _httpHandlerOptionsCreator = httpHandlerOptionsCreator;
         }
 
         public async Task<Response<IOcelotConfiguration>> Create()
@@ -143,6 +146,8 @@ namespace Ocelot.Configuration.Creator
 
             var region = _regionCreator.Create(fileReRoute);
 
+            var httpHandlerOptions = _httpHandlerOptionsCreator.Create(fileReRoute);
+
             var reRoute = new ReRouteBuilder()
                 .WithDownstreamPathTemplate(fileReRoute.DownstreamPathTemplate)
                 .WithUpstreamPathTemplate(fileReRoute.UpstreamPathTemplate)
@@ -168,6 +173,7 @@ namespace Ocelot.Configuration.Creator
                 .WithQosOptions(qosOptions)
                 .WithEnableRateLimiting(fileReRouteOptions.EnableRateLimiting)
                 .WithRateLimitOptions(rateLimitOption)
+                .WithHttpHandlerOptions(httpHandlerOptions)
                 .Build();
 
             await SetupLoadBalancer(reRoute);

--- a/src/Ocelot/Configuration/Creator/HttpHandlerOptionsCreator.cs
+++ b/src/Ocelot/Configuration/Creator/HttpHandlerOptionsCreator.cs
@@ -1,0 +1,13 @@
+﻿using Ocelot.Configuration.File;
+
+namespace Ocelot.Configuration.Creator
+{
+    public class HttpHandlerOptionsCreator : IHttpHandlerOptionsCreator
+    {
+        public HttpHandlerOptions Create(FileReRoute fileReRoute)
+        {
+            return new HttpHandlerOptions(fileReRoute.HttpHandlerOptions.AllowAutoRedirect,
+                fileReRoute.HttpHandlerOptions.UseCookieContainer);
+        }
+    }
+}

--- a/src/Ocelot/Configuration/Creator/IHttpHandlerOptionsCreator.cs
+++ b/src/Ocelot/Configuration/Creator/IHttpHandlerOptionsCreator.cs
@@ -1,0 +1,12 @@
+﻿using Ocelot.Configuration.File;
+
+namespace Ocelot.Configuration.Creator
+{
+    /// <summary>
+    /// Describes creation of HttpHandlerOptions
+    /// </summary>
+    public interface IHttpHandlerOptionsCreator
+    {
+        HttpHandlerOptions Create(FileReRoute fileReRoute);
+    }
+}

--- a/src/Ocelot/Configuration/File/FileHttpHandlerOptions.cs
+++ b/src/Ocelot/Configuration/File/FileHttpHandlerOptions.cs
@@ -1,0 +1,15 @@
+﻿namespace Ocelot.Configuration.File
+{
+    public class FileHttpHandlerOptions
+    {
+        public FileHttpHandlerOptions()
+        {
+            AllowAutoRedirect = true;
+            UseCookieContainer = true;
+        }
+
+        public bool AllowAutoRedirect { get; set; }
+
+        public bool UseCookieContainer { get; set; }
+    }
+}

--- a/src/Ocelot/Configuration/File/FileReRoute.cs
+++ b/src/Ocelot/Configuration/File/FileReRoute.cs
@@ -15,6 +15,7 @@ namespace Ocelot.Configuration.File
             FileCacheOptions = new FileCacheOptions();
             QoSOptions = new FileQoSOptions();
             RateLimitOptions = new FileRateLimitRule();
+            HttpHandlerOptions = new FileHttpHandlerOptions();
         }
 
         public string DownstreamPathTemplate { get; set; }
@@ -35,5 +36,6 @@ namespace Ocelot.Configuration.File
         public FileQoSOptions QoSOptions { get; set; }
         public string LoadBalancer {get;set;}
         public FileRateLimitRule RateLimitOptions { get; set; }
+        public FileHttpHandlerOptions HttpHandlerOptions { get; set; }
     }
 }

--- a/src/Ocelot/Configuration/HttpHandlerOptions.cs
+++ b/src/Ocelot/Configuration/HttpHandlerOptions.cs
@@ -1,0 +1,25 @@
+﻿namespace Ocelot.Configuration
+{
+    /// <summary>
+    /// Describes configuration parameters for http handler, 
+    /// that is created to handle a request to service
+    /// </summary>
+    public class HttpHandlerOptions
+    {
+        public HttpHandlerOptions(bool allowAutoRedirect, bool useCookieContainer)
+        {
+            AllowAutoRedirect = allowAutoRedirect;
+            UseCookieContainer = useCookieContainer;
+        }
+
+        /// <summary>
+        /// Specify if auto redirect is enabled
+        /// </summary>
+        public bool AllowAutoRedirect { get; private set; }
+
+        /// <summary>
+        /// Specify is handler has to use a cookie container
+        /// </summary>
+        public bool UseCookieContainer { get; private set; }
+    }
+}

--- a/src/Ocelot/Configuration/ReRoute.cs
+++ b/src/Ocelot/Configuration/ReRoute.cs
@@ -29,7 +29,8 @@ namespace Ocelot.Configuration
             bool isQos,
             QoSOptions qosOptions,
             bool enableEndpointRateLimiting,
-            RateLimitOptions ratelimitOptions)
+            RateLimitOptions ratelimitOptions,
+            HttpHandlerOptions httpHandlerOptions)
         {
             ReRouteKey = reRouteKey;
             ServiceProviderConfiguraion = serviceProviderConfiguraion;
@@ -58,6 +59,7 @@ namespace Ocelot.Configuration
             QosOptionsOptions = qosOptions;
             EnableEndpointEndpointRateLimiting = enableEndpointRateLimiting;
             RateLimitOptions = ratelimitOptions;
+            HttpHandlerOptions = httpHandlerOptions;
         }
 
         public string ReRouteKey {get;private set;}
@@ -84,5 +86,6 @@ namespace Ocelot.Configuration
         public ServiceProviderConfiguration ServiceProviderConfiguraion { get; private set; }
         public bool EnableEndpointEndpointRateLimiting { get; private set; }
         public RateLimitOptions RateLimitOptions { get; private set; }
+        public HttpHandlerOptions HttpHandlerOptions { get; private set; }
     }
 }

--- a/src/Ocelot/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Ocelot/DependencyInjection/ServiceCollectionExtensions.cs
@@ -84,6 +84,7 @@ namespace Ocelot.DependencyInjection
             services.TryAddSingleton<IQoSOptionsCreator, QoSOptionsCreator>();
             services.TryAddSingleton<IReRouteOptionsCreator, ReRouteOptionsCreator>();
             services.TryAddSingleton<IRateLimitOptionsCreator, RateLimitOptionsCreator>();
+            services.TryAddSingleton<IHttpHandlerOptionsCreator, HttpHandlerOptionsCreator>();
 
             var identityServerConfiguration = IdentityServerConfigurationCreator.GetIdentityServerConfiguration();
             

--- a/src/Ocelot/Request/Builder/HttpRequestCreator.cs
+++ b/src/Ocelot/Request/Builder/HttpRequestCreator.cs
@@ -10,9 +10,11 @@ namespace Ocelot.Request.Builder
         public async Task<Response<Request>> Build(
             HttpRequestMessage httpRequestMessage,
             bool isQos,
-            IQoSProvider qosProvider)
+            IQoSProvider qosProvider,
+            bool useCookieContainer,
+            bool allowAutoRedirect)
         {
-            return new OkResponse<Request>(new Request(httpRequestMessage, isQos, qosProvider));
+            return new OkResponse<Request>(new Request(httpRequestMessage, isQos, qosProvider, useCookieContainer, allowAutoRedirect));
         }
     }
 }

--- a/src/Ocelot/Request/Builder/IRequestCreator.cs
+++ b/src/Ocelot/Request/Builder/IRequestCreator.cs
@@ -11,6 +11,8 @@
         Task<Response<Request>> Build(
             HttpRequestMessage httpRequestMessage,
             bool isQos,
-            IQoSProvider qosProvider);
+            IQoSProvider qosProvider,
+            bool useCookieContainer,
+            bool allowAutoRedirect);
     }
 }

--- a/src/Ocelot/Request/Middleware/HttpRequestBuilderMiddleware.cs
+++ b/src/Ocelot/Request/Middleware/HttpRequestBuilderMiddleware.cs
@@ -46,7 +46,9 @@ namespace Ocelot.Request.Middleware
             var buildResult = await _requestCreator.Build(
                     DownstreamRequest,
                     DownstreamRoute.ReRoute.IsQos,
-                    qosProvider.Data);
+                    qosProvider.Data,
+                    DownstreamRoute.ReRoute.HttpHandlerOptions.UseCookieContainer,
+                    DownstreamRoute.ReRoute.HttpHandlerOptions.AllowAutoRedirect);
 
             if (buildResult.IsError)
             {

--- a/src/Ocelot/Request/Request.cs
+++ b/src/Ocelot/Request/Request.cs
@@ -8,15 +8,21 @@ namespace Ocelot.Request
         public Request(
             HttpRequestMessage httpRequestMessage, 
             bool isQos,
-            IQoSProvider qosProvider)
+            IQoSProvider qosProvider, 
+            bool allowAutoRedirect,
+            bool useCookieContainer)
         {
             HttpRequestMessage = httpRequestMessage;
             IsQos = isQos;
             QosProvider = qosProvider;
+            AllowAutoRedirect = allowAutoRedirect;
+            UseCookieContainer = useCookieContainer;
         }
 
         public HttpRequestMessage HttpRequestMessage { get; private set; }
         public bool IsQos { get; private set; }
         public IQoSProvider QosProvider { get; private set; }
+        public bool AllowAutoRedirect { get; private set; }
+        public bool UseCookieContainer { get; private set; }
     }
 }

--- a/src/Ocelot/Requester/HttpClientBuilder.cs
+++ b/src/Ocelot/Requester/HttpClientBuilder.cs
@@ -20,9 +20,9 @@ namespace Ocelot.Requester
             return this;
         }  
 
-        public IHttpClient Create()
+        public IHttpClient Create(bool useCookies, bool allowAutoRedirect)
         {
-            var httpclientHandler = new HttpClientHandler();
+            var httpclientHandler = new HttpClientHandler { AllowAutoRedirect = allowAutoRedirect, UseCookies = useCookies};
             
             var client = new HttpClient(CreateHttpMessageHandler(httpclientHandler));                
             

--- a/src/Ocelot/Requester/HttpClientHttpRequester.cs
+++ b/src/Ocelot/Requester/HttpClientHttpRequester.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Ocelot.Configuration;
 using Ocelot.Logging;
 using Ocelot.Responses;
 using Polly.CircuitBreaker;
@@ -14,7 +15,8 @@ namespace Ocelot.Requester
         private readonly IHttpClientCache _cacheHandlers;
         private readonly IOcelotLogger _logger;
 
-        public HttpClientHttpRequester(IOcelotLoggerFactory loggerFactory, IHttpClientCache cacheHandlers)
+        public HttpClientHttpRequester(IOcelotLoggerFactory loggerFactory, 
+            IHttpClientCache cacheHandlers)
         {
             _logger = loggerFactory.CreateLogger<HttpClientHttpRequester>();
             _cacheHandlers = cacheHandlers;
@@ -25,8 +27,8 @@ namespace Ocelot.Requester
             var builder = new HttpClientBuilder();
 
             var cacheKey = GetCacheKey(request, builder);
-
-            var httpClient = GetHttpClient(cacheKey, builder);
+            
+            var httpClient = GetHttpClient(cacheKey, builder, request.UseCookieContainer, request.AllowAutoRedirect);
 
             try
             {
@@ -54,13 +56,13 @@ namespace Ocelot.Requester
 
         }
 
-        private IHttpClient GetHttpClient(string cacheKey, IHttpClientBuilder builder)
+        private IHttpClient GetHttpClient(string cacheKey, IHttpClientBuilder builder, bool useCookieContainer, bool allowAutoRedirect)
         {
             var httpClient = _cacheHandlers.Get(cacheKey);
 
             if (httpClient == null)
             {
-                httpClient = builder.Create();
+                httpClient = builder.Create(useCookieContainer, allowAutoRedirect);
             }
             return httpClient;
         }

--- a/src/Ocelot/Requester/IHttpClientBuilder.cs
+++ b/src/Ocelot/Requester/IHttpClientBuilder.cs
@@ -15,11 +15,13 @@ namespace Ocelot.Requester
         /// <summary>
         /// Sets a PollyCircuitBreakingDelegatingHandler .
         /// </summary>
-        IHttpClientBuilder WithQos(IQoSProvider qosProvider, IOcelotLogger logger);            
+        IHttpClientBuilder WithQos(IQoSProvider qosProvider, IOcelotLogger logger);
 
         /// <summary>
         /// Creates the <see cref="HttpClient"/>
         /// </summary>
-        IHttpClient Create();
+        /// <param name="useCookies">Defines if http client should use cookie container</param>
+        /// <param name="allowAutoRedirect">Defines if http client should allow auto redirect</param>
+        IHttpClient Create(bool useCookies, bool allowAutoRedirect);
     }
 }

--- a/test/Ocelot.UnitTests/Configuration/HttpHandlerOptionsCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/HttpHandlerOptionsCreatorTests.cs
@@ -1,0 +1,71 @@
+﻿using Ocelot.Configuration;
+using Ocelot.Configuration.Creator;
+using Ocelot.Configuration.File;
+using Shouldly;
+using TestStack.BDDfy;
+using Xunit;
+
+namespace Ocelot.UnitTests.Configuration
+{
+
+    public class HttpHandlerOptionsCreatorTests
+    {
+        private readonly IHttpHandlerOptionsCreator _httpHandlerOptionsCreator;
+        private FileReRoute _fileReRoute;
+        private HttpHandlerOptions _httpHandlerOptions;
+
+        public HttpHandlerOptionsCreatorTests()
+        {
+            _httpHandlerOptionsCreator = new HttpHandlerOptionsCreator();
+        }
+
+        [Fact]
+        public void should_create_options_with_useCookie_and_allowAutoRedirect_true_as_default()
+        {
+            var fileReRoute = new FileReRoute();
+            var expectedOptions = new HttpHandlerOptions(true, true);
+
+            this.Given(x => GivenTheFollowing(fileReRoute))
+                .When(x => WhenICreateHttpHandlerOptions())
+                .Then(x => ThenTheFollowingOptionsReturned(expectedOptions))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_create_options_with_specified_useCookie_and_allowAutoRedirect()
+        {
+            var fileReRoute = new FileReRoute
+            {
+                HttpHandlerOptions = new FileHttpHandlerOptions
+                {
+                    AllowAutoRedirect = false,
+                    UseCookieContainer = false
+                }
+            };
+
+            var expectedOptions = new HttpHandlerOptions(false, false);
+
+            this.Given(x => GivenTheFollowing(fileReRoute))
+                .When(x => WhenICreateHttpHandlerOptions())
+                .Then(x => ThenTheFollowingOptionsReturned(expectedOptions))
+                .BDDfy();
+        }
+
+        private void GivenTheFollowing(FileReRoute fileReRoute)
+        {
+            _fileReRoute = fileReRoute;
+        }
+
+        private void WhenICreateHttpHandlerOptions()
+        {
+            _httpHandlerOptions = _httpHandlerOptionsCreator.Create(_fileReRoute);
+        }
+
+        private void ThenTheFollowingOptionsReturned(HttpHandlerOptions options)
+        {
+            _httpHandlerOptions.ShouldNotBeNull();
+            _httpHandlerOptions.AllowAutoRedirect.ShouldBe(options.AllowAutoRedirect);
+            _httpHandlerOptions.UseCookieContainer.ShouldBe(options.UseCookieContainer);
+        }
+    }
+}

--- a/test/Ocelot.UnitTests/Request/HttpRequestBuilderMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/Request/HttpRequestBuilderMiddlewareTests.cs
@@ -15,6 +15,7 @@
     using TestStack.BDDfy;
     using Xunit;
     using Ocelot.Requester.QoS;
+    using Ocelot.Configuration;
     using Microsoft.AspNetCore.Builder;
 
     public class HttpRequestBuilderMiddlewareTests : ServerHostedMiddlewareTest
@@ -50,12 +51,13 @@
                 new ReRouteBuilder()
                     .WithRequestIdKey("LSRequestId")
                     .WithUpstreamHttpMethod(new List<string> { "Get" })
+                    .WithHttpHandlerOptions(new HttpHandlerOptions(true, true))
                     .Build());
 
             this.Given(x => x.GivenTheDownStreamUrlIs("any old string"))
                 .And(x => x.GivenTheQosProviderHouseReturns(new OkResponse<IQoSProvider>(new NoQoSProvider())))
                 .And(x => x.GivenTheDownStreamRouteIs(downstreamRoute))
-                .And(x => x.GivenTheRequestBuilderReturns(new Ocelot.Request.Request(new HttpRequestMessage(), true, new NoQoSProvider())))
+                .And(x => x.GivenTheRequestBuilderReturns(new Ocelot.Request.Request(new HttpRequestMessage(), true, new NoQoSProvider(), false, false)))
                 .When(x => x.WhenICallTheMiddleware())
                 .Then(x => x.ThenTheScopedDataRepositoryIsCalledCorrectly())
                 .BDDfy();
@@ -103,7 +105,11 @@
             _request = new OkResponse<Ocelot.Request.Request>(request);
 
             _requestBuilder
-                .Setup(x => x.Build(It.IsAny<HttpRequestMessage>(), It.IsAny<bool>(), It.IsAny<IQoSProvider>()))
+                .Setup(x => x.Build(It.IsAny<HttpRequestMessage>(),
+                                    It.IsAny<bool>(),
+                                    It.IsAny<IQoSProvider>(),
+                                    It.IsAny<bool>(),
+                                    It.IsAny<bool>()))
                 .ReturnsAsync(_request);
         }
 

--- a/test/Ocelot.UnitTests/Request/HttpRequestCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Request/HttpRequestCreatorTests.cs
@@ -15,6 +15,9 @@
         private readonly bool _isQos;
         private readonly IQoSProvider _qoSProvider;
         private readonly HttpRequestMessage _requestMessage;
+        private readonly bool _useCookieContainer;
+        private readonly bool _allowAutoRedirect;
+
         private Response<Ocelot.Request.Request> _response;
 
         public HttpRequestCreatorTests()
@@ -22,6 +25,9 @@
             _requestCreator = new HttpRequestCreator();
             _isQos = true;
             _qoSProvider = new NoQoSProvider();
+            _useCookieContainer = false;
+            _allowAutoRedirect = false;
+
             _requestMessage = new HttpRequestMessage();
         }
 
@@ -30,12 +36,19 @@
         {
             this.When(x => x.WhenIBuildARequest())
                 .Then(x => x.ThenTheRequestContainsTheRequestMessage())
+                .Then(x => x.ThenTheRequestContainsTheIsQos())
+                .Then(x => x.ThenTheRequestContainsTheQosProvider())
+                .Then(x => x.ThenTheRequestContainsUseCookieContainer())
+                .Then(x => x.ThenTheRequestContainsAllowAutoRedirect())
                 .BDDfy();
         }
 
         private void WhenIBuildARequest()
         {
-            _response = _requestCreator.Build(_requestMessage, _isQos, _qoSProvider).GetAwaiter().GetResult();
+            _response = _requestCreator.Build(_requestMessage,
+                    _isQos, _qoSProvider, _useCookieContainer, _allowAutoRedirect)
+                .GetAwaiter()
+                .GetResult();
         }
 
         private void ThenTheRequestContainsTheRequestMessage()
@@ -51,6 +64,16 @@
         private void ThenTheRequestContainsTheQosProvider()
         {
             _response.Data.QosProvider.ShouldBe(_qoSProvider);
+        }
+
+        private void ThenTheRequestContainsUseCookieContainer()
+        {
+            _response.Data.UseCookieContainer.ShouldBe(_useCookieContainer);
+        }
+
+        private void ThenTheRequestContainsAllowAutoRedirect()
+        {
+            _response.Data.AllowAutoRedirect.ShouldBe(_allowAutoRedirect);
         }
     }
 }

--- a/test/Ocelot.UnitTests/Requester/HttpRequesterMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/Requester/HttpRequesterMiddlewareTests.cs
@@ -28,7 +28,7 @@
         [Fact]
         public void should_call_scoped_data_repository_correctly()
         {
-            this.Given(x => x.GivenTheRequestIs(new Ocelot.Request.Request(new HttpRequestMessage(),true, new NoQoSProvider())))
+            this.Given(x => x.GivenTheRequestIs(new Ocelot.Request.Request(new HttpRequestMessage(),true, new NoQoSProvider(), false, false)))
                 .And(x => x.GivenTheRequesterReturns(new HttpResponseMessage()))
                 .And(x => x.GivenTheScopedRepoReturns())
                 .When(x => x.WhenICallTheMiddleware())


### PR DESCRIPTION
HttpHandlerOptions are added to ReRoute configuration and passed down to HttpClientHttpRequester as Request properties.

NB! Properties in FileHttpHandlerOptions are set to true as default not to ruin already existing applications