### PR TITLE
looking at #135 validation

### DIFF
--- a/src/Ocelot/Configuration/Validator/DownstreamPathTemplateDoesntStartWithForwardSlash.cs
+++ b/src/Ocelot/Configuration/Validator/DownstreamPathTemplateDoesntStartWithForwardSlash.cs
@@ -1,0 +1,12 @@
+using Ocelot.Errors;
+
+namespace Ocelot.Configuration.Validator
+{
+    public class PathTemplateDoesntStartWithForwardSlash : Error
+    {
+        public PathTemplateDoesntStartWithForwardSlash(string message) 
+            : base(message, OcelotErrorCode.PathTemplateDoesntStartWithForwardSlash)
+        {
+        }
+    }
+}

--- a/src/Ocelot/Configuration/Validator/FileConfigurationValidator.cs
+++ b/src/Ocelot/Configuration/Validator/FileConfigurationValidator.cs
@@ -26,6 +26,20 @@ namespace Ocelot.Configuration.Validator
                 return new OkResponse<ConfigurationValidationResult>(result);
             }
 
+            result = CheckDownstreamTemplatePathBeingsWithForwardSlash(configuration);
+
+            if (result.IsError)
+            {
+                return new OkResponse<ConfigurationValidationResult>(result);
+            }
+
+            result = CheckUpstreamTemplatePathBeingsWithForwardSlash(configuration);
+
+            if (result.IsError)
+            {
+                return new OkResponse<ConfigurationValidationResult>(result);
+            }
+
             result = await CheckForUnsupportedAuthenticationProviders(configuration);
 
             if (result.IsError)
@@ -47,6 +61,46 @@ namespace Ocelot.Configuration.Validator
             }
 
             return new OkResponse<ConfigurationValidationResult>(result);
+        }
+
+        private ConfigurationValidationResult CheckDownstreamTemplatePathBeingsWithForwardSlash(FileConfiguration configuration)
+        {   
+            var errors = new List<Error>();
+
+            foreach(var reRoute in configuration.ReRoutes)
+            {
+                if(!reRoute.DownstreamPathTemplate.StartsWith("/"))
+                {
+                    errors.Add(new PathTemplateDoesntStartWithForwardSlash($"{reRoute.DownstreamPathTemplate} doesnt start with forward slash"));
+                }
+            }
+
+            if(errors.Any())
+            {
+                return new ConfigurationValidationResult(true, errors);
+            }
+
+            return new ConfigurationValidationResult(false, errors);
+        }
+
+        private ConfigurationValidationResult CheckUpstreamTemplatePathBeingsWithForwardSlash(FileConfiguration configuration)
+        {   
+            var errors = new List<Error>();
+
+            foreach(var reRoute in configuration.ReRoutes)
+            {
+                if(!reRoute.UpstreamPathTemplate.StartsWith("/"))
+                {
+                    errors.Add(new PathTemplateDoesntStartWithForwardSlash($"{reRoute.DownstreamPathTemplate} doesnt start with forward slash"));
+                }
+            }
+
+            if(errors.Any())
+            {
+                return new ConfigurationValidationResult(true, errors);
+            }
+
+            return new ConfigurationValidationResult(false, errors);
         }
 
         private async Task<ConfigurationValidationResult> CheckForUnsupportedAuthenticationProviders(FileConfiguration configuration)

--- a/src/Ocelot/Errors/OcelotErrorCode.cs
+++ b/src/Ocelot/Errors/OcelotErrorCode.cs
@@ -31,6 +31,7 @@
         UnableToFindQoSProviderError,
         UnableToSetConfigInConsulError,
         UnmappableRequestError,
-        RateLimitOptionsError
+        RateLimitOptionsError,
+        PathTemplateDoesntStartWithForwardSlash
     }
 }

--- a/test/Ocelot.AcceptanceTests/CustomMiddlewareTests.cs
+++ b/test/Ocelot.AcceptanceTests/CustomMiddlewareTests.cs
@@ -119,7 +119,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         new FileReRoute
                         {
-                            DownstreamPathTemplate = "41879/",
+                            DownstreamPathTemplate = "/41879/",
                             DownstreamPort = 41879,
                             DownstreamScheme = "http",
                             DownstreamHost = "localhost",

--- a/test/Ocelot.AcceptanceTests/RoutingTests.cs
+++ b/test/Ocelot.AcceptanceTests/RoutingTests.cs
@@ -111,7 +111,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         new FileReRoute
                         {
-                            DownstreamPathTemplate = "api/products",
+                            DownstreamPathTemplate = "/api/products",
                             DownstreamScheme = "http",
                             DownstreamHost = "localhost",
                             DownstreamPort = 51879,

--- a/test/Ocelot.UnitTests/Configuration/ConfigurationValidationTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/ConfigurationValidationTests.cs
@@ -57,12 +57,50 @@ namespace Ocelot.UnitTests.Configuration
                     new FileReRoute
                     {
                         DownstreamPathTemplate = "/api/products/",
-                        UpstreamPathTemplate = "http://asdf.com"
+                        UpstreamPathTemplate = "/asdf/"
                     }
                 }
             }))
                 .When(x => x.WhenIValidateTheConfiguration())
                 .Then(x => x.ThenTheResultIsValid())
+                .BDDfy();
+        }
+
+        [Fact]
+        public void configuration_is_invalid_without_slash_prefix_downstream_path_template()
+        {
+            this.Given(x => x.GivenAConfiguration(new FileConfiguration
+            {
+                ReRoutes = new List<FileReRoute>
+                {
+                    new FileReRoute
+                    {
+                        DownstreamPathTemplate = "api/products/",
+                        UpstreamPathTemplate = "/asdf/"
+                    }
+                }
+            }))
+                .When(x => x.WhenIValidateTheConfiguration())
+                .Then(x => x.ThenTheResultIsNotValid())
+                .BDDfy();
+        }
+
+        [Fact]
+        public void configuration_is_invalid_without_slash_prefix_upstream_path_template()
+        {
+            this.Given(x => x.GivenAConfiguration(new FileConfiguration
+            {
+                ReRoutes = new List<FileReRoute>
+                {
+                    new FileReRoute
+                    {
+                        DownstreamPathTemplate = "/api/products/",
+                        UpstreamPathTemplate = "api/prod/",
+                    }
+                }
+            }))
+                .When(x => x.WhenIValidateTheConfiguration())
+                .Then(x => x.ThenTheResultIsNotValid())
                 .BDDfy();
         }
 
@@ -76,7 +114,7 @@ namespace Ocelot.UnitTests.Configuration
                     new FileReRoute
                     {
                         DownstreamPathTemplate = "/api/products/",
-                        UpstreamPathTemplate = "http://asdf.com",
+                        UpstreamPathTemplate = "/asdf/",
                         AuthenticationOptions = new FileAuthenticationOptions()
                         {
                             AuthenticationProviderKey = "Test"
@@ -90,14 +128,6 @@ namespace Ocelot.UnitTests.Configuration
                 .BDDfy();
         }
 
-        private void GivenTheAuthSchemeExists(string name)
-        {
-            _provider.Setup(x => x.GetAllSchemesAsync()).ReturnsAsync(new List<AuthenticationScheme>
-            {
-                new AuthenticationScheme(name, name, typeof(TestHandler))
-            });
-        }
-
         [Fact]
         public void configuration_is_invalid_with_invalid_authentication_provider()
         {
@@ -108,7 +138,7 @@ namespace Ocelot.UnitTests.Configuration
                     new FileReRoute
                     {
                         DownstreamPathTemplate = "/api/products/",
-                        UpstreamPathTemplate = "http://asdf.com",
+                        UpstreamPathTemplate = "/asdf/",
                         AuthenticationOptions = new FileAuthenticationOptions()
                         {
                             AuthenticationProviderKey = "Test"
@@ -131,12 +161,12 @@ namespace Ocelot.UnitTests.Configuration
                     new FileReRoute
                     {
                         DownstreamPathTemplate = "/api/products/",
-                        UpstreamPathTemplate = "http://asdf.com"
+                        UpstreamPathTemplate = "/asdf/"
                     },
                     new FileReRoute
                     {
                         DownstreamPathTemplate = "http://www.bbc.co.uk",
-                        UpstreamPathTemplate = "http://asdf.com"
+                        UpstreamPathTemplate = "/asdf/"
                     }
                 }
             }))
@@ -169,6 +199,14 @@ namespace Ocelot.UnitTests.Configuration
         private void ThenTheErrorIs<T>()
         {
             _result.Data.Errors[0].ShouldBeOfType<T>();
+        }
+
+        private void GivenTheAuthSchemeExists(string name)
+        {
+            _provider.Setup(x => x.GetAllSchemesAsync()).ReturnsAsync(new List<AuthenticationScheme>
+            {
+                new AuthenticationScheme(name, name, typeof(TestHandler))
+            });
         }
 
         private class TestOptions : AuthenticationSchemeOptions

--- a/test/Ocelot.UnitTests/Responder/ErrorsToHttpStatusCodeMapperTests.cs
+++ b/test/Ocelot.UnitTests/Responder/ErrorsToHttpStatusCodeMapperTests.cs
@@ -120,7 +120,7 @@ namespace Ocelot.UnitTests.Responder
             // If this test fails then it's because the number of error codes has changed.
             // You should make the appropriate changes to the test cases here to ensure
             // they cover all the error codes, and then modify this assertion.
-            Enum.GetNames(typeof(OcelotErrorCode)).Length.ShouldBe(30, "Looks like the number of error codes has changed. Do you need to modify ErrorsToHttpStatusCodeMapper?");
+            Enum.GetNames(typeof(OcelotErrorCode)).Length.ShouldBe(31, "Looks like the number of error codes has changed. Do you need to modify ErrorsToHttpStatusCodeMapper?");
         }
 
         private void ShouldMapErrorToStatusCode(OcelotErrorCode errorCode, HttpStatusCode expectedHttpStatusCode)


### PR DESCRIPTION
fix #135 

Added validation so Ocelot wont run if upstream and downstream template paths dont start with a forward slash "/"..

I could have just added it if it didnt exist but will try this approach first. I'd rather people manage their own configuration than the code change it without them knowing!