### PR TITLE
Add acceptance test that exposes JSON deserialization bug from #146

### DIFF
--- a/test/Ocelot.AcceptanceTests/Caching/InMemoryJsonHandle.cs
+++ b/test/Ocelot.AcceptanceTests/Caching/InMemoryJsonHandle.cs
@@ -1,0 +1,137 @@
+﻿using CacheManager.Core;
+using CacheManager.Core.Internal;
+using CacheManager.Core.Logging;
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using static CacheManager.Core.Utility.Guard;
+
+namespace Ocelot.AcceptanceTests.Caching
+{
+	public class InMemoryJsonHandle<TCacheValue> : BaseCacheHandle<TCacheValue>
+	{
+		private readonly ICacheSerializer _serializer;
+		private readonly ConcurrentDictionary<string, Tuple<Type, byte[]>> _cache;
+
+		public InMemoryJsonHandle(
+			ICacheManagerConfiguration managerConfiguration,
+			CacheHandleConfiguration configuration,
+			ICacheSerializer serializer,
+			ILoggerFactory loggerFactory) : base(managerConfiguration, configuration)
+		{
+			_cache = new ConcurrentDictionary<string, Tuple<Type, byte[]>>();
+			_serializer = serializer;
+			Logger = loggerFactory.CreateLogger(this);
+		}
+
+		public override int Count => _cache.Count;
+
+		protected override ILogger Logger { get; }
+
+		public override void Clear() => _cache.Clear();
+
+		public override void ClearRegion(string region)
+		{
+			NotNullOrWhiteSpace(region, nameof(region));
+
+			var key = string.Concat(region, ":");
+			foreach (var item in _cache.Where(p => p.Key.StartsWith(key, StringComparison.OrdinalIgnoreCase)))
+			{
+				_cache.TryRemove(item.Key, out Tuple<Type, byte[]> val);
+			}
+		}
+
+		public override bool Exists(string key)
+		{
+			NotNullOrWhiteSpace(key, nameof(key));
+
+			return _cache.ContainsKey(key);
+		}
+
+		public override bool Exists(string key, string region)
+		{
+			NotNullOrWhiteSpace(region, nameof(region));
+			var fullKey = GetKey(key, region);
+			return _cache.ContainsKey(fullKey);
+		}
+
+		protected override bool AddInternalPrepared(CacheItem<TCacheValue> item)
+		{
+			NotNull(item, nameof(item));
+
+			var key = GetKey(item.Key, item.Region);
+
+			var serializedItem = _serializer.SerializeCacheItem(item);
+
+			return _cache.TryAdd(key, new Tuple<Type, byte[]>(item.Value.GetType(), serializedItem));
+		}
+
+		protected override CacheItem<TCacheValue> GetCacheItemInternal(string key) => GetCacheItemInternal(key, null);
+
+		protected override CacheItem<TCacheValue> GetCacheItemInternal(string key, string region)
+		{
+			var fullKey = GetKey(key, region);
+
+			CacheItem<TCacheValue> deserializedResult = null;
+
+			if (_cache.TryGetValue(fullKey, out Tuple<Type, byte[]> result))
+			{
+				deserializedResult = _serializer.DeserializeCacheItem<TCacheValue>(result.Item2, result.Item1);
+
+				if (deserializedResult.ExpirationMode != ExpirationMode.None && IsExpired(deserializedResult, DateTime.UtcNow))
+				{
+					_cache.TryRemove(fullKey, out Tuple<Type, byte[]> removeResult);
+					TriggerCacheSpecificRemove(key, region, CacheItemRemovedReason.Expired, deserializedResult.Value);
+					return null;
+				}
+			}
+
+			return deserializedResult;
+		}
+
+		protected override void PutInternalPrepared(CacheItem<TCacheValue> item)
+		{
+			NotNull(item, nameof(item));
+
+			var serializedItem = _serializer.SerializeCacheItem<TCacheValue>(item);
+
+			_cache[GetKey(item.Key, item.Region)] = new Tuple<Type, byte[]>(item.Value.GetType(), serializedItem);
+		}
+
+		protected override bool RemoveInternal(string key) => RemoveInternal(key, null);
+
+		protected override bool RemoveInternal(string key, string region)
+		{
+			var fullKey = GetKey(key, region);
+			return _cache.TryRemove(fullKey, out Tuple<Type, byte[]> val);
+		}
+
+		private static string GetKey(string key, string region)
+		{
+			NotNullOrWhiteSpace(key, nameof(key));
+
+			if (string.IsNullOrWhiteSpace(region))
+			{
+				return key;
+			}
+
+			return string.Concat(region, ":", key);
+		}
+
+		private static bool IsExpired(CacheItem<TCacheValue> item, DateTime now)
+		{
+			if (item.ExpirationMode == ExpirationMode.Absolute
+				&& item.CreatedUtc.Add(item.ExpirationTimeout) < now)
+			{
+				return true;
+			}
+			else if (item.ExpirationMode == ExpirationMode.Sliding
+				&& item.LastAccessedUtc.Add(item.ExpirationTimeout) < now)
+			{
+				return true;
+			}
+
+			return false;
+		}
+	}
+}

--- a/test/Ocelot.AcceptanceTests/ConfigurationInConsulTests.cs
+++ b/test/Ocelot.AcceptanceTests/ConfigurationInConsulTests.cs
@@ -100,14 +100,14 @@ namespace Ocelot.AcceptanceTests
 					{
 						Provider = "Consul",
 						Host = "localhost",
-						Port = 9500
+						Port = 9502
 					}
 				}
 			};
 
-			var fakeConsulServiceDiscoveryUrl = "http://localhost:9500";
+			var fakeConsulServiceDiscoveryUrl = "http://localhost:9502";
 
-			var consulConfig = new ConsulRegistryConfiguration("localhost", 9500, "Ocelot");
+			var consulConfig = new ConsulRegistryConfiguration("localhost", 9502, "Ocelot");
 
 			this.Given(x => GivenThereIsAFakeConsulServiceDiscoveryProvider(fakeConsulServiceDiscoveryUrl))
 				.And(x => x.GivenThereIsAServiceRunningOn("http://localhost:51779", 200, "Hello from Laura"))

--- a/test/Ocelot.AcceptanceTests/Ocelot.AcceptanceTests.csproj
+++ b/test/Ocelot.AcceptanceTests/Ocelot.AcceptanceTests.csproj
@@ -30,6 +30,7 @@
 </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="CacheManager.Serialization.Json" Version="1.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20171031-01" />


### PR DESCRIPTION
I have created a test that exposes the deserialization problem from issue #146 where `DownstreamRoute.ReRoute.CacheOptions` is null when fetched from cache.

I created a custom cache handle for CacheManager that mimics the behavior of the `DictionaryHandle` but uses the `ICacheSerializer` to serialize/deserialize values with Json.Net before saving them to an internal Dictionary.
When the handle tries to deserialize the saved configuration, it skips `CacheOptions` key because it mismatches with `fileCacheOptions`.
You can see the test failing if you revert the change on `ReRoute.cs` from 50ec8f17ea3dc6a817ece9a44fd71374c0d4e788

Don't know if this is overkill but couldn't think of any better way to expose this.