### PR TITLE
Can't set StatusCode after Response has started

### DIFF
--- a/src/Ocelot/Errors/Middleware/ExceptionHandlerMiddleware.cs
+++ b/src/Ocelot/Errors/Middleware/ExceptionHandlerMiddleware.cs
@@ -85,7 +85,10 @@ namespace Ocelot.Errors.Middleware
 
         private void SetInternalServerErrorOnResponse(HttpContext context)
         {
-            context.Response.StatusCode = 500;
+            if (!context.Response.HasStarted)
+            {
+                context.Response.StatusCode = 500;
+            }
         }
 
         private string CreateMessage(HttpContext context, Exception e)


### PR DESCRIPTION
As same middleware (like [ClientRateLimitMiddleware](https://github.com/TomPallister/Ocelot/blob/develop/src/Ocelot/RateLimit/Middleware/ClientRateLimitMiddleware.cs#L124)) may has set StatusCode,  resetting StatusCode by ExceptionHandlerMiddleware causes exception:
```
System.InvalidOperationException: Status code cannot be set, response has already started.
``` 